### PR TITLE
ci: Use uvx to build sdist and wheel

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,16 +16,21 @@ jobs:
 
     permissions:
       id-token: write
-      
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Package the files
+
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Build a sdist and wheel
       run: |
         set -eux
 
-        pip install build
-        python -m build --sdist
+        uvx --from build pyproject-build
+
+    - name: Validate package structure with twine
+      run: uvx twine check --strict dist/*
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Install dependencies and build
 on:
     pull_request:
       branches: [ "main" ]
+    workflow_dispatch:
 
 jobs:
   build:
@@ -11,10 +12,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Package the files
+
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Build a sdist and wheel
       run: |
         set -eux
 
-        pip install build
-        python -m build --sdist
+        uvx --from build pyproject-build
+
+    - name: Validate package structure with twine
+      run: uvx twine check --strict dist/*


### PR DESCRIPTION
Resolves #5 

* Build both an sdist and wheel for distribution.
* Instead of relying on an unspecified GitHub Actions base distribution Python use uvx, provided through uv, to run pyproject-build (the executable that the 'build' Python package actually provides) in an isolated virtual environment that is created on the fly by uv. This avoids installing things into the GitHub Actions environment unless necessary.
* Use uvx to validate the distributions with twine.
* Add workflow_dispatch run control option for the build workflow to allow for on demand build checks.

![image](https://github.com/user-attachments/assets/43410967-a2c4-4aca-8d18-a386d81f2418)
