### PR TITLE
https URLs and functions to set the dataset in the notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ atom.available_data()
 Retrieves the list of URLs corresponding to one of the keys listed by `available_data()`.
 
 Args:
-- `data_key`: key for the dataset required. This vary with the scope. Options are given by `available_data()` in each scope.
-- `protocol`: protocol for the URLs. Options: 'root' and 'https'.
+- `data_key` : For non-beta releases (e.g. '2015', '2016', etc.), the data key to look up.
+- `skim` : Only for the 2025e-13tev-beta release: the skim name to look up.
 
 **Usage:**
 ```python
-data = get_urls_data('2016', protocol='https')
+data = get_urls_data(data_key='2016', protocol='https')
 ```
 ## Notebooks utilities description and usage 
 ### `install_from_environment(*packages, environment_file)`
@@ -139,27 +139,44 @@ import atlasopenmagic as atom
 atom.install_from_environment("coffea", "pandas", environment_file="./myfile.yml")
 ```
 
-### `build_dataset(defs, skim='noskim', protocol='https')`
-Build dataset dictionaries for analysis notebooks.
-
+### `build_mc_dataset(mc_defs, skim='noskim', protocol='https')`
+Build a dict of MC samples URLs.
+    
 Args:
-- `defs`: dictionary where keys are sample types and containing a list with DIDs and an optiona color parameter.
-- `skim`: skim to use for the whole dataset. Only available for the `2025e-13tev-beta` release.
-- `protocol`: protocol for the urls.
+- `mc_defs`: dictionary with DIDs and optional color: `{ sample_name: {'list': [...urls...], 'color': ...}, … }`
+- `skim` : the MC skim tag (only meaningful in the 2025e-13tev-beta release)
+- `protocol` : 'root' or 'https'
 
 **Usage:**
 ```python
 import atlasopenmagic as atom
-defs = {
-    'Data':                     {'color':'red'},             
-    r'Background $t\bar t$':    {'dids':[410470], 'color':'yellow'},
-    r'Background $V+$jets':     {'dids':[700335,700336,700337], 'color':'orange'},
-    r'Background Diboson':      {'dids':[700488,700489,700490,700491], 'color':'green'},
-    r'Background $ZZ^{*}$':     {'dids':[700600,700601], 'color':'#ff0000'},
-    r'Signal ($m_H$=125 GeV)':  {'dids':[345060,346228], 'color':'#00cdff'},
+mc_defs = {
+    r'Background $t\bar t$':    {'dids': [410470],                      'color': 'yellow'},
+    r'Background $V+$jets':     {'dids': [700335,700336,700337],        'color': 'orange'},
+    r'Background Diboson':      {'dids': [700488,700489,700490,700491],'color': 'green'},
+    r'Background $ZZ^{*}$':     {'dids': [700600,700601],               'color': '#ff0000'},
+    r'Signal ($m_H$=125 GeV)':  {'dids': [345060,346228],              'color': '#00cdff'},
 }
 
-samples  = atom.build_dataset(defs, skim='2bjets', protocol='https')
+mc_samples = build_mc_dataset(mc_defs, skim='2bjets', protocol='https')
+```
+
+### `build_data_dataset(data_defs, data_keys, protocol='https')`
+Build a dict of Data samples URLS.
+
+Args:
+- `data_defs`: dictionary with data keys, as listed in `available_data`, and optional color: `{ sample_name: {'keys': [...urls...], 'color': ...}, … }`
+- `data_keys` : a single key or list of keys to fetch via get_urls_data
+- `protocol` : 'root' or 'https'
+
+**Usage:**
+```python
+import atlasopenmagic as atom
+data_defs = {
+    'Data': {'data': ['2015'], 'color': 'red'},
+}
+
+data_samples = build_data_dataset(data_defs, data_keys=['2015','2016'], protocol='root')
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -68,12 +68,19 @@ print(release)
 ### `set_release(release)`
 Set the release (scope) in which to look for information (research open data, education 8 TeV, et). The `release` passed to the function has to be one of the keys listed by `available_releases()`.
 
+Args:
+- `release`: name of the release to use.
+
 **Usage:**
 ```python
 atom.set_release('2024r-pp')
 ```
-### `get_metadata(key, *var)`
+### `get_metadata(key, var)`
 Get metadata information for MC data.
+
+Args:
+- `key`: Dataset ID.
+- `var`: Variable to retrieve.
 
 **Usage:**
 You can get a dictionary with all the metadata
@@ -88,26 +95,35 @@ The available variables are: `dataset_id`, `short_name`, `e-tag`, `cross_section
 
 The keys to be used for research data are the Dataset IDs found in the [Monte Carlo Metadata](https://opendata.atlas.cern/docs/data/for_research/metadata)
 
-### `get_urls(key)`
+### `get_urls(key, skim, protocol)`
 Retrieves the list of URLs corresponding to a given key. This is used for MC data.
+
+Args:
+- `key`: Dataset ID.
+- `skim`: Skim for the dataset. This parameter is only taken into account when using the `2025e-13tev-beta` release.
+- `protocol`: protocol for the URLs. Options: 'root' and 'https'.
 
 **Usage:**
 ```python
-urls = atom.get_urls('12345')
+urls = atom.get_urls('12345', protocol='root')
 ```
 ### `available_data()`
-Retrieves the list of keys for the data available for a scope.
+Retrieves the list of keys for the data available for a scope/release.
 
 **Usage:**
 ```python
 atom.available_data()
 ```
-### `get_urls_data(data_key)`
+### `get_urls_data(data_key, protocol)`
 Retrieves the list of URLs corresponding to one of the keys listed by `available_data()`.
+
+Args:
+- `data_key`: key for the dataset required. This vary with the scope. Options are given by `available_data()` in each scope.
+- `protocol`: protocol for the URLs. Options: 'root' and 'https'.
 
 **Usage:**
 ```python
-data = get_urls_data('2016')
+data = get_urls_data('2016', protocol='https')
 ```
 ## Notebooks utilities description and usage 
 ### `install_from_environment(*packages, environment_file)`
@@ -121,6 +137,29 @@ Args:
 ```python
 import atlasopenmagic as atom
 atom.install_from_environment("coffea", "pandas", environment_file="./myfile.yml")
+```
+
+### `build_dataset(defs, skim='noskim', protocol='https')`
+Build dataset dictionaries for analysis notebooks.
+
+Args:
+- `defs`: dictionary where keys are sample types and containing a list with DIDs and an optiona color parameter.
+- `skim`: skim to use for the whole dataset.
+- `protocol`: protocol for the urls.
+
+**Usage:**
+```python
+import atlasopenmagic as atom
+defs = {
+    'Data':                     {'color':'red'},             
+    r'Background $t\bar t$':    {'dids':[410470], 'color':'yellow'},
+    r'Background $V+$jets':     {'dids':[700335,700336,700337], 'color':'orange'},
+    r'Background Diboson':      {'dids':[700488,700489,700490,700491], 'color':'green'},
+    r'Background $ZZ^{*}$':     {'dids':[700600,700601], 'color':'#ff0000'},
+    r'Signal ($m_H$=125 GeV)':  {'dids':[345060,346228], 'color':'#00cdff'},
+}
+
+samples  = atom.build_dataset(defs, skim='2bjets', protocol='https')
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Args:
 ```python
 import atlasopenmagic as atom
 data_defs = {
-    'Data': {'data': ['2015'], 'color': 'red'},
+    'Data': {'color': 'red'},
 }
 
 data_samples = build_data_dataset(data_defs, data_keys=['2015','2016'], protocol='root')

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ atom.install_from_environment("coffea", "pandas", environment_file="./myfile.yml
 Build a dict of MC samples URLs.
     
 Args:
-- `mc_defs`: dictionary with DIDs and optional color: `{ sample_name: {'list': [...urls...], 'color': ...}, … }`
-- `skim` : the MC skim tag (only meaningful in the 2025e-13tev-beta release)
-- `protocol` : 'root' or 'https'
+- `mc_defs`: Dictionary with DIDs and optional color: `{ sample_name: {'list': [...urls...], 'color': ...}, … }`
+- `skim` : The MC skim tag (only meaningful in the 2025e-13tev-beta release)
+- `protocol` : Protocol to use for URLs.
 
 **Usage:**
 ```python
@@ -161,22 +161,20 @@ mc_defs = {
 mc_samples = build_mc_dataset(mc_defs, skim='2bjets', protocol='https')
 ```
 
-### `build_data_dataset(data_defs, data_keys, protocol='https')`
+### `build_data_dataset(data_keys, name="Data", color=None, protocol="https")`
 Build a dict of Data samples URLS.
 
 Args:
-- `data_defs`: dictionary with data keys, as listed in `available_data`, and optional color: `{ sample_name: {'keys': [...urls...], 'color': ...}, … }`
-- `data_keys` : a single key or list of keys to fetch via get_urls_data
-- `protocol` : 'root' or 'https'
+- `data_keys`: The data_key(s) to fetch (e.g. '2015' or ['2015','2016']).
+- `name`: The key under which the sample appears in the returned dict.
+- `color`: A color string to attach to the sample.
+- `protocol` : Protocol to use for URLs.
 
 **Usage:**
 ```python
 import atlasopenmagic as atom
-data_defs = {
-    'Data': {'color': 'red'},
-}
 
-data_samples = build_data_dataset(data_defs, data_keys=['2015','2016'], protocol='root')
+data_samples = build_data_samples("2bjets", name="Data", color="red", protocol="root")
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Build dataset dictionaries for analysis notebooks.
 
 Args:
 - `defs`: dictionary where keys are sample types and containing a list with DIDs and an optiona color parameter.
-- `skim`: skim to use for the whole dataset.
+- `skim`: skim to use for the whole dataset. Only available for the `2025e-13tev-beta` release.
 - `protocol`: protocol for the urls.
 
 **Usage:**

--- a/atlasopenmagic/__init__.py
+++ b/atlasopenmagic/__init__.py
@@ -9,7 +9,8 @@ from .metadata import (
 )
 
 from .utils import (
-    install_from_environment
+    install_from_environment,
+    build_dataset
 )
 
 # List of public functions available when importing the package

--- a/atlasopenmagic/__init__.py
+++ b/atlasopenmagic/__init__.py
@@ -10,7 +10,8 @@ from .metadata import (
 
 from .utils import (
     install_from_environment,
-    build_dataset
+    build_mc_dataset,
+    build_data_dataset
 )
 
 # List of public functions available when importing the package
@@ -22,5 +23,7 @@ __all__ = [
     "get_current_release",
     "get_urls_data",
     "available_data",
-    "install_from_environment"
+    "install_from_environment",
+    "build_mc_dataset",
+    "build_data_dataset",
 ]

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -143,6 +143,15 @@ def get_urls(key, skim='noskim', protocol='root'):
       - If the skim value is not found, an error is raised showing the available skim options.
     For other releases, the skim parameter is ignored and all URLs are returned.
     """
+
+    # If they’re asking for a skim outside of 13 TeV‐β, warn them
+    if current_release != '2025e-13tev-beta' and skim != 'noskim':
+        warnings.warn(
+            f"Skims are only availabe in the '2025e-13tev-beta' release; "
+            f"in release '{current_release}' all skims are ignored.",
+            UserWarning
+        )
+
     global _url_code_mapping
 
     # Check if the URL mapping cache has been loaded; if not, load it.
@@ -183,7 +192,6 @@ def get_urls(key, skim='noskim', protocol='root'):
         raise ValueError(f"Invalid protocol '{proto}'. Must be 'root' or 'https'.")
 
     return [_apply_protocol(u, proto) for u in raw_urls]
-
 
 def available_data():
     """

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -213,9 +213,21 @@ def get_urls_data(key, protocol='root'):
     current_data_mapping = url_mapping_data.get(current_release)
     if current_data_mapping is None:
         raise ValueError(f"Current release '{current_release}' not found in url_mapping_data.")
+
+     # Branch on release to decide whether `key` is a skim or a data_key
+    if current_release == '2025e-13tev-beta':
+        skim = key
+        available = ', '.join(current_data_mapping.keys())
+        raw_urls = current_data_mapping.get(skim)
+        if raw_urls is None:
+            raise ValueError(f"Invalid skim '{skim}'. Available skims: {available}.")
+    else:
+        data_key = key
+        available = ', '.join(current_data_mapping.keys())
+        raw_urls = current_data_mapping.get(data_key)
+        if raw_urls is None:
+            raise ValueError(f"Invalid data key '{data_key}'. Available data keys: {available}.")
     
-    # Get the URLs for the given key
-    raw_urls = current_data_mapping.get(key)
     # If the key is not found, raise an error
     if raw_urls is None:
         available_keys = ', '.join(current_data_mapping.keys())

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -3,6 +3,7 @@ import re
 import threading
 import csv
 import requests
+import warnings
 from pprint import pprint
 from atlasopenmagic.data.id_matches import id_matches, id_matches_8TeV, id_matches_13TeVbeta
 from atlasopenmagic.data.urls_mc import url_mapping

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -121,35 +121,39 @@ def install_from_environment(*packages, environment_file=None):
             "Make sure the package names exactly match the beginning of the package entries in the file.\n"
         )
 
-def build_dataset(defs, skim='noskim', protocol='https'):
+def build_mc_dataset(mc_defs, skim='noskim', protocol='https'):
     """
-    Build a dictionary of datasets urls for use in analysis notebooks.
+    Build a dict of MC samples URLs.
     """
     out = {}
-    for name, info in defs.items():
-        color   = info.get('color')
-        if 'dids' in info:
-            # MC sample
-            out[name] = _make_mc_sample(*info['dids'], skim=skim, protocol=protocol, color=color)
-        else:
-            # Data sample
-            out[name] = _make_data_sample(skim, protocol=protocol, color=color)
+    for name, info in mc_defs.items():
+        urls = []
+        for did in info['dids']:
+            urls.extend(get_urls(str(did), skim=skim, protocol=protocol))
+        sample = {'list': urls}
+        if 'color' in info:
+            sample['color'] = info['color']
+        out[name] = sample
     return out
 
-#### Internal Helper Functions ####
-def _make_mc_sample(*dids, skim, protocol, color=None):
+def build_data_dataset(data_defs, data_keys, protocol='https'):
     """
-    Build a url dict for one or more MC DIDs
+    Build a dict of Data samples URLS.
     """
-    urls = []
-    for did in dids:
-        urls.extend(get_urls(str(did), skim, protocol))
-    sample = {'list': urls}
-    if color is not None:
-        sample['color'] = color
-    return sample
+    # normalize data_keys to a list
+    if isinstance(data_keys, str):
+        data_keys = [data_keys]
 
-def _make_data_sample(skim, protocol, color=None):
+    out = {}
+    for name, info in data_defs.items():
+        urls = []
+        for key in data_keys:
+            urls.extend(get_urls_data(key, protocol=protocol))
+        sample = {'list': urls}
+        if 'color' in info:
+            sample['color'] = info['color']
+        out[name] = sample
+    return out
     """
     Build a url dict for detector data
     """

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -136,29 +136,21 @@ def build_mc_dataset(mc_defs, skim='noskim', protocol='https'):
         out[name] = sample
     return out
 
-def build_data_dataset(data_defs, data_keys, protocol='https'):
+def build_data_dataset(data_keys, name="Data", color=None, protocol="https"):
     """
-    Build a dict of Data samples URLS.
+    Retrieve and group one or more detector data‐keys under a single sample.
     """
-    # normalize data_keys to a list
     if isinstance(data_keys, str):
         data_keys = [data_keys]
 
-    out = {}
-    for name, info in data_defs.items():
-        urls = []
-        for key in data_keys:
-            urls.extend(get_urls_data(key, protocol=protocol))
-        sample = {'list': urls}
-        if 'color' in info:
-            sample['color'] = info['color']
-        out[name] = sample
-    return out
-    """
-    Build a url dict for detector data
-    """
-    urls = get_urls_data(skim, protocol)
-    sample = {'list': urls}
+    # Gather all URLs
+    urls = []
+    for key in data_keys:
+        urls.extend(get_urls_data(key, protocol=protocol))
+
+    # Build the single‐sample dict
+    sample = {"list": urls}
     if color is not None:
-        sample['color'] = color
-    return sample
+        sample["color"] = color
+
+    return {name: sample}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atlasopenmagic"
-version = "0.4.0"
+version = "0.5.0"
 description = "A utility package for retrieving ATLAS open data URLs and metadata."
 authors = [
     { name="ATLAS Collaboration", email='atlas-outreach-opendata-support@cern.ch'}

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch
-from atlasopenmagic.metadata import get_urls
+import atlasopenmagic.metadata as m
+from atlasopenmagic.metadata import get_urls, get_urls_data
 
 def test_get_urls_700200():
     """
@@ -60,3 +61,77 @@ def test_get_urls_none_key():
     """
     with pytest.raises(ValueError):
         get_urls(None)
+
+def test_get_urls_root():
+    # Default protocol is 'root'
+    urls = get_urls(346342)
+    assert urls == [
+        "root://eospublic.cern.ch//eos/opendata/atlas/rucio/"
+        "mc20_13TeV/DAOD_PHYSLITE.37865954._000001.pool.root.1"
+    ]
+
+def test_get_urls_https():
+    urls = get_urls(346342, protocol="https")
+    assert urls == [
+        "https://opendata.cern.ch//eos/opendata/atlas/rucio/"
+        "mc20_13TeV/DAOD_PHYSLITE.37865954._000001.pool.root.1"
+    ]
+
+def test_get_urls_data_invalid_key():
+    """Invalid data key should raise ValueError."""
+    with pytest.raises(ValueError):
+        get_urls_data('THIS_KEY_DOES_NOT_EXIST')
+
+def test_get_urls_data_invalid_protocol():
+    """Passing a bad protocol to get_urls_data should raise ValueError."""
+    # pick any real key from the current data mapping
+    real_key = next(iter(m.url_mapping_data[m.current_release].keys()))
+    with pytest.raises(ValueError):
+        get_urls_data(real_key, protocol='ftp')
+
+def test_get_urls_data_root():
+    # By default (protocol='root'), the first URL should be the EOS root path
+    urls = get_urls_data('2015')
+    assert urls[0] == (
+        "root://eospublic.cern.ch//eos/opendata/atlas/rucio/"
+        "data15_13TeV/DAOD_PHYSLITE.37001626._000001.pool.root.1"
+    )
+
+def test_get_urls_data_https():
+    # When overriding to HTTPS, that same entry should be rewritten
+    urls = get_urls_data('2015', protocol="https")
+    assert urls[0] == (
+        "https://opendata.cern.ch//eos/opendata/atlas/rucio/"
+        "data15_13TeV/DAOD_PHYSLITE.37001626._000001.pool.root.1"
+    )
+
+# Needs to be last because it changes the release
+def get_urls_skim_parameter():
+    """
+    Verify that get_urls respects the skim argument
+    in the 2025e-13tev-beta release.
+    """
+    # 1) Switch to the beta release
+    m.set_release('2025e-13tev-beta')
+
+    # 2) Inject a tiny dummy mapping for our fake dataset code 'XYZ'
+    m._url_code_mapping = {
+        'XYZ': {
+            'noskim': ['root://eospublic.cern.ch/fake/XYZ_noskim.root'],
+            'custom': ['root://eospublic.cern.ch/fake/XYZ_custom.root'],
+        }
+    }
+    # 3) Map the user key '123' to our dummy code 'XYZ'
+    m.ID_MATCH_LOOKUP['2025e-13tev-beta'] = {'123': 'XYZ'}
+
+    # Default skim should be 'noskim'
+    urls = get_urls('123')
+    assert urls == ['root://eospublic.cern.ch/fake/XYZ_noskim.root']
+
+    # Override skim explicitly
+    urls = get_urls('123', skim='custom')
+    assert urls == ['root://eospublic.cern.ch/fake/XYZ_custom.root']
+
+    # Invalid skim name should raise
+    with pytest.raises(ValueError):
+        get_urls('123', skim='doesNotExist')


### PR DESCRIPTION
1. Now `get_urls` and `get_urls_data` return https URLs using the `protocol` argument.
2. Added a couple of functions for getting the dataset setup for the notebooks

In the beta release it would look like:
```
mc_defs = {
    r'Background $t\bar t$':    {'dids': [410470],                      'color': 'yellow'},
    r'Background $V+$jets':     {'dids': [700335,700336,700337],        'color': 'orange'},
    r'Background Diboson':      {'dids': [700488,700489,700490,700491],'color': 'green'},
    r'Background $ZZ^{*}$':     {'dids': [700600,700601],               'color': '#ff0000'},
    r'Signal ($m_H$=125 GeV)':  {'dids': [345060,346228],              'color': '#00cdff'},
}

mc_samples   = build_mc_dataset(mc_defs,   skim='2bjets', protocol='https')
data_samples = build_data_dataset('2bjets',  color='red', protocol='https')

samples = {**data_samples, **mc_samples}
```

Also added some test because we didn't had test for a couple of stuff I added before.