### PR TITLE
Adding https caching functionality from fsspec

### DIFF
--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -126,7 +126,9 @@ def _apply_protocol(url, protocol):
 
     Args:
         url (str): The base 'root://' URL.
-        protocol (str): The target protocol ('https', 'eos', or 'root').
+        protocol (str): The target protocol ('https', 'https-cache', 'eos', or 'root').
+        https-cache uses the 'simplecache' functionality of fsspec to copy input
+        files locally rather than streaming them
 
     Returns:
         str: The transformed URL.
@@ -142,6 +144,9 @@ def _apply_protocol(url, protocol):
     if protocol == 'root':
         # Return the original URL for direct ROOT access
         return url
+    if protocol == 'https-cache':
+        return url.replace('root://eospublic.cern.ch:1094/',
+                           'simplecache::https://opendata.cern.ch')
     raise ValueError(
         f"Invalid protocol '{protocol}'. Must be 'root', 'https', or 'eos'.")
 


### PR DESCRIPTION
Now that we have a new version of fsspec, we can use the simplecache functionality to significantly reduce the load we place on the webserver holding the open data