### PR TITLE
Distinguishing metadata and all info

### DIFF
--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -244,9 +244,9 @@ def set_release(release):
             f"Active release set to: {current_release}. Metadata cache cleared.")
 
 
-def get_metadata(key, var=None, cache=True):
+def get_all_info(key, var=None, cache=True):
     """
-    Retrieves metadata for a given dataset, identified by its number or physics short name.
+    Retrieves all the information for a given dataset, identified by its number or physics short name.
 
     If the cache is empty for the current release, this function will trigger a fetch
     from the API to populate it.
@@ -257,7 +257,7 @@ def get_metadata(key, var=None, cache=True):
                              metadata dictionary is returned. Supports old and new field names.
 
     Returns:
-        dict or any: The full metadata dictionary for the dataset, or the value of the
+        dict or any: The full info dictionary for the dataset, or the value of the
                      single field if 'var' was specified.
 
     Raises:
@@ -292,7 +292,7 @@ def get_metadata(key, var=None, cache=True):
             f"Invalid key: '{key_str}'. \
             No dataset found with this ID or name in release '{current_release}'.")
 
-    # If no specific variable is requested, return the whole dictionary.
+    # If no specific variable is requested, return almost the whole dictionary.
     if not var:
         return sample_data
 
@@ -303,6 +303,29 @@ def get_metadata(key, var=None, cache=True):
 
     raise ValueError(
         f"Invalid field name: '{var}'. Available fields: {', '.join(sorted(set(AVAILABLE_FIELDS)))}")
+
+
+def get_metadata(key, var=None, cache=True):
+    """
+    Retrieves the metadata (no file lists) for a given dataset, identified by its number or physics short name.
+
+    If the cache is empty for the current release, this function will trigger a fetch
+    from the API to populate it.
+
+    Args:
+        key (str or int): The dataset identifier (e.g., '301204').
+        var (str, optional): A specific metadata field to retrieve. If None, the entire
+                             metadata dictionary is returned. Supports old and new field names.
+
+    Returns:
+        dict or any: The full metadata dictionary for the dataset, or the value of the
+                     single field if 'var' was specified.
+
+    Raises:
+        ValueError: If the dataset key or the specified variable field is not found.
+    """
+    all_info = get_all_info(key, var, cache)
+    return { x:all_info[x] for x in all_info if x not in ['skims','file_list'] }
 
 
 def get_urls(key, skim='noskim', protocol='root'):


### PR DESCRIPTION
Adding a separate helper function that gets all the information, so that the get_metadata helper function can be made to provide only the metadata, not the file locations (those can also be gotten separately from the get_urls function). Addresses the suggestion made in discussions on !102