### PR TITLE
Adding caching functionality for files

### DIFF
--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -330,7 +330,7 @@ def get_metadata(key, var=None, cache=True):
     return all_info
 
 
-def get_urls(key, skim='noskim', protocol='root'):
+def get_urls(key, skim='noskim', protocol='root', cache=False):
     """
     Retrieves file URLs for a given dataset, with options for skims and protocols.
 
@@ -342,6 +342,8 @@ def get_urls(key, skim='noskim', protocol='root'):
                               unfiltered dataset. Other examples: 'exactly4lep', '3lep'.
         protocol (str, optional): The desired URL protocol. Can be 'root', 'https', or 'eos'.
                                   Defaults to 'root'.
+        cache (bool, optional): use the simplecache mechanism of fsspec to locally cache
+                                files instead of streaming them
 
     Returns:
         list[str]: A list of file URLs matching the criteria.
@@ -378,7 +380,9 @@ def get_urls(key, skim='noskim', protocol='root'):
     # Retrieve the correct list of URLs and apply the requested protocol
     # transformation.
     raw_urls = available_files[skim]
-    return [_apply_protocol(u, protocol.lower()) for u in raw_urls]
+    # If caching is requested, add it to the paths we return
+    cache_str = 'simplecache::' if cache else ''
+    return [cache_str+_apply_protocol(u, protocol.lower()) for u in raw_urls]
 
 
 def available_datasets():
@@ -469,14 +473,14 @@ def match_metadata(field, value, float_tolerance=0.01):
 # --- Deprecated Functions (for backward compatibility) ---
 
 
-def get_urls_data(key, protocol='root'):
+def get_urls_data(key, protocol='root', cache=False):
     """
     DEPRECATED: Retrieves file URLs for the base (unskimmed) dataset.
 
-    Please use get_urls(key, skim='noskim', protocol=protocol) instead.
+    Please use get_urls(key, skim='noskim', protocol=protocol, cache=cache) instead.
     """
     warnings.warn(
         "get_urls_data() is deprecated. Please use get_urls() instead.",
         DeprecationWarning,
         stacklevel=2)
-    return get_urls("data", skim=key, protocol=protocol)
+    return get_urls("data", skim=key, protocol=protocol, cache=cache)

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -142,22 +142,32 @@ def install_from_environment(*packages, environment_file=None):
             "Make sure the package names exactly match the beginning of the package entries in the file.\n")
 
 
-def build_dataset(samples_defs, skim='noskim', protocol='https'):
+def build_dataset(samples_defs, skim='noskim', protocol='https', cache=False):
     """
     Build a dict of MC samples URLs.
+
+    Args:
+        samples_defs (dict[str,dict]: The datasets to be built up with their definitions and
+                                      colors. See examples for more info.
+        skim (str, optional): The desired skim type. Defaults to 'noskim' for the base,
+                              unfiltered dataset. Other examples: 'exactly4lep', '3lep'.
+        protocol (str, optional): The desired URL protocol. Can be 'root', 'https', or 'eos'.
+                                  Defaults to 'root'.
+        cache (bool, optional): use the simplecache mechanism of fsspec to locally cache
+                                files instead of streaming them
     """
     out = {}
     for name, info in samples_defs.items():
         urls = []
         for did in info['dids']:
-            urls.extend(get_urls(str(did), skim=skim, protocol=protocol))
+            urls.extend(get_urls(str(did), skim=skim, protocol=protocol, cache=cache))
         sample = {'list': urls}
         if 'color' in info:
             sample['color'] = info['color']
         out[name] = sample
     return out
 
-def build_data_dataset(data_keys, name="Data", color=None, protocol="https"):
+def build_data_dataset(data_keys, name="Data", color=None, protocol="https", cache=False):
     warnings.warn(
         "The build_data_dataset function is deprecated. "
         "Use build_dataset with the appropriate data definitions instead.",
@@ -166,13 +176,14 @@ def build_data_dataset(data_keys, name="Data", color=None, protocol="https"):
     return build_dataset(
         {name: {'dids': ["data"], 'color': color}},
         skim=data_keys,
-        protocol=protocol
+        protocol=protocol,
+        cache=cache
     )
 
-def build_mc_dataset(mc_defs, skim='noskim', protocol='https'):
+def build_mc_dataset(mc_defs, skim='noskim', protocol='https', cache=False):
     warnings.warn(
         "The build_mc_dataset function is deprecated. "
         "Use build_dataset with the appropriate MC definitions instead.",
         DeprecationWarning
     )
-    return build_dataset(mc_defs, skim=skim, protocol=protocol)
+    return build_dataset(mc_defs, skim=skim, protocol=protocol, cache=cache)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlasopenmagic"
-version = "1.1.0"
+version = "1.2.0"
 description = "A utility package for retrieving ATLAS open data URLs and metadata."
 authors = [
     { name="ATLAS Collaboration", email="atlas-outreach-opendata-support@cern.ch" }


### PR DESCRIPTION
This adds the use of 'simplecache::' in fsspec to be able to locally download files and use them there instead of streaming them. Includes a version bump.