### PR TITLE
feat: remove configuration of warnings module

### DIFF
--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -33,14 +33,6 @@ import warnings
 import requests
 from requests.exceptions import HTTPError
 
-def warn_with_color(message, category, filename, lineno, file=None, line=None):
-    RED = '\033[91m'
-    RESET = '\033[0m'
-    print(f"{RED}{category.__name__}: {message} ({filename}:{lineno}){RESET}")
-
-warnings.showwarning = warn_with_color
-warnings.simplefilter('always', DeprecationWarning)
-
 # --- Global Configuration & State ---
 
 # The active release can be set via the 'ATLAS_RELEASE' environment variable.

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -12,10 +12,7 @@ import subprocess
 from pathlib import Path
 import yaml
 import requests
-from atlasopenmagic.metadata import get_urls, warn_with_color
-
-warnings.showwarning = warn_with_color
-warnings.simplefilter('always', DeprecationWarning)
+from atlasopenmagic.metadata import get_urls
 
 def install_from_environment(*packages, environment_file=None):
     """


### PR DESCRIPTION
Configuring `warnings` can affect the behavior of other libraries in unintuitive ways, so this is best avoided when using `atlasopenmagic` as a library together with others. As an example,

```python
import warnings
import atlasopenmagic

for _ in range(10):
    warnings.warn("something", DeprecationWarning)
```

will print ten warnings in red and without the `import atlasopenmagic` it will print one warning in a different format. The deprecation warnings in the code will still show up by default, only when users suppress them by configuring `warnings` themselves will they go away (and then it is on the user to deal with this responsibility).

resolves #31 