### PR TITLE
Adding local metadata save/load functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,35 @@ Retrieves the list of keys for the data available for a scope/release.
 ```python
 atom.available_data()
 ```
+### `get_all_metadata()`
+Retrieves the current dictionary of metadata, in its entirety.
+
+**Usage:**
+```python
+my_metadata = atom.get_all_metadata()
+```
+### `save_metadata(file_name)`
+Saves the metadata to an output file. Currently supports writing to json or txt file.
+
+Args:
+- `file_name`: the name of the file to save the metadata to, with full path and extension.
+
+**Usage:**
+```python
+save_metadata('metadata.json')
+```
+### `read_metadata(file_name, release)`
+Reads the metadata from a file. Currently supports reading from json.
+
+Args:
+- `file_name`: the name of the file to load the metadata from, with full path
+- `release`: the name of the release for this metadata; default 'custom'
+
+**Usage:**
+```python
+read_metadata('metadata.json', release='2024r-pp')
+```
+
 ### ❗**DEPRECATED** `get_urls_data(data_key, protocol)`
   
 *Please use `get_urls(key, skim='noskim', protocol=protocol, cache=False)` instead.*
@@ -170,6 +199,7 @@ Args:
 ```python
 data = get_urls_data(data_key='2016', protocol='https')
 ```
+
 ## Notebooks utilities description and usage 
 ### `install_from_environment(*packages, environment_file)`
 Install specific packages listed in an `environment.yml` file via pip.

--- a/atlasopenmagic/__init__.py
+++ b/atlasopenmagic/__init__.py
@@ -13,6 +13,9 @@ from .metadata import (
     available_datasets,
     available_keywords,
     match_metadata,
+    save_metadata,
+    read_metadata,
+    get_all_metadata,
 )
 
 from .utils import (
@@ -34,6 +37,9 @@ __all__ = [
     "available_datasets",
     "available_keywords",
     "match_metadata",
+    "save_metadata",
+    "read_metadata",
+    "get_all_metadata",
     "install_from_environment",
     "build_dataset",
     "build_mc_dataset",

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -569,6 +569,19 @@ def available_datasets():
     return sorted([k for k in _metadata if k.isdigit() or k == "data"])
 
 
+def get_all_metadata():
+    """
+    Returns the entire metadata dictionary, en mass
+    Returns:
+        The metadata dictionary
+    """
+    with _metadata_lock:
+        # Ensure the cache is populated before reading from it.
+        if not _metadata:
+            _fetch_and_cache_release_data(current_release)
+    return _metadata
+
+
 # --- Metadata search functions
 
 
@@ -644,6 +657,77 @@ def match_metadata(field, value, float_tolerance=0.01):
             "No datasets found. Check for capitalization and spelling issues in field and value in particular."
         )
     return sorted(matches)
+
+
+# --- Metadata saving and loading functions ---
+
+
+def save_metadata(file_name='metadata.json'):
+    """
+    Save the metadata in an output file.
+    Attempts to adjust the output based on the file extension, currently supporting txt and json.
+    Loads the metadata if it is currently empty.
+
+    Args:
+        file_name: the name of the file to save the metadata to, with full path and extension.
+    """
+    # Check if metadata is already loaded, load it if needed
+    with _metadata_lock:
+        # Ensure the cache is populated before reading from it.
+        if not _metadata:
+            _fetch_and_cache_release_data(current_release)
+
+    # If they request json file saving, we have a very easy time
+    if file_name.endswith('.json'):
+        import json
+        with open(file_name,'w') as outfile:
+            json.dump(
+                _metadata,
+                outfile,
+                indent=2,
+                sort_keys=True,
+                ensure_ascii=False,
+                separators=(",", ": "),
+            )
+    # If they want text files, just use pretty print
+    elif file_name.endswith('.txt'):
+        import pprint
+        with open(file_name,'w') as outfile:
+            pprint.pprint(
+                    _metadata,
+                    outfile,
+                    indent=2)
+    # No other formats supported at this time
+    else:
+        raise ValueError(f'Requested metadata saving to unsupported filetype: {file_name.split(".")[-1]}. Currently supporting txt and json.')
+
+def read_metadata(file_name='metadata.json', release='custom'):
+    """
+    Reads the metadata from an input file.
+    Overwrites existing metadata.
+
+    Args:
+        file_name: the name of the file to load the metadata from, with full path
+        release: the name of the release for this metadata; default 'custom'
+    """
+    # Grab the global _metadata object and current release so that we can adjust them
+    global _metadata, current_release
+
+    # Let the users know that we heard them
+    print(f'Loading metadata from {file_name}, and setting release to {release}')
+
+    # Lock it up so that noone else is writing to it at the moment
+    with _metadata_lock:
+        # Now load the metadata. We'll take it all, directly, just like we saved it above
+        import json
+        with open(file_name,'r') as input_metadata:
+            my_metadata = json.load(input_metadata)
+            if not isinstance(my_metadata,dict):
+                raise ValueError(f'Did not get a dictionary as expected from {file_name}. Will not load metadata.')
+            _metadata = my_metadata
+
+        # Now set the release if all went according to plan
+        current_release = release
 
 
 # --- Deprecated Functions (for backward compatibility) ---

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -586,6 +586,9 @@ def empty_metadata():
     """
     Internal helper function to empty the metadata cache and leave it empty
     """
+    # Make sure we work with the global object
+    global _metadata
+    # Clear the cache
     with _metadata_lock:
         _metadata = {}
 

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -582,6 +582,14 @@ def get_all_metadata():
     return _metadata
 
 
+def empty_metadata():
+    """
+    Internal helper function to empty the metadata cache and leave it empty
+    """
+    with _metadata_lock:
+        _metadata = {}
+
+
 # --- Metadata search functions
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlasopenmagic"
-version = "1.3.1"
+version = "1.4.0"
 description = "A utility package for retrieving ATLAS open data URLs and metadata."
 authors = [
     { name="ATLAS Collaboration", email="atlas-outreach-opendata-support@cern.ch" }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -396,6 +396,8 @@ def test_save_read_metadata():
     with pytest.raises(ValueError):
         atom.read_metadata('test_file.json')
 
+    # Ensure the cache is cleared
+    atom.set_release('2024r-pp')
 
 def test_get_all_metadata():
     """
@@ -404,6 +406,8 @@ def test_get_all_metadata():
     # Then test that we can get all the metadata
     my_metadata = atom.get_all_metadata()
 
+    # Ensure the cache is cleared
+    atom.set_release('2024r-pp')
 
 def test_internals():
     """
@@ -415,3 +419,6 @@ def test_internals():
     assert metadata._convert_to_local(test_path) == "/fake/path/mock_data/noskim_301204.root"
     # Check that if we start with our local path, we just get our path back
     assert metadata._convert_to_local(test_path,'/fake/path') == "/fake/path/mock_data/noskim_301204.root"
+
+    # Ensure the cache is cleared
+    atom.set_release('2024r-pp')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -373,8 +373,9 @@ def test_save_read_metadata():
     """
     Test that we can save metadata to a json file and read it back, and get back what we wrote
     """
-    # Ensure the cache is cleared
-    atom.set_release('2024r-pp')
+    # Empty out the cache first
+    from atlasopenmagic import metadata
+    metadata.empty_metadata()
 
     # First test that we can save the metadata
     atom.save_metadata('local_metadata.json')
@@ -411,14 +412,11 @@ def test_get_all_metadata():
     """
     Test function to get all metadata without a warm cache
     """
-    # Ensure the cache is cleared
-    atom.set_release('2024r-pp')
-
+    # Empty out the cache first
+    from atlasopenmagic import metadata
+    metadata.empty_metadata()
     # Then test that we can get all the metadata
     my_metadata = atom.get_all_metadata()
-
-    # Ensure the cache is cleared
-    atom.set_release('2024r-pp')
 
 def test_internals():
     """
@@ -430,6 +428,3 @@ def test_internals():
     assert metadata._convert_to_local(test_path) == "/fake/path/mock_data/noskim_301204.root"
     # Check that if we start with our local path, we just get our path back
     assert metadata._convert_to_local(test_path,'/fake/path') == "/fake/path/mock_data/noskim_301204.root"
-
-    # Ensure the cache is cleared
-    atom.set_release('2024r-pp')

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -378,26 +378,26 @@ def test_save_read_metadata():
     metadata.empty_metadata()
 
     # First test that we can save the metadata
-    atom.save_metadata('local_metadata.json')
+    metadata.save_metadata('local_metadata.json')
     # Write it to a text file as well - we don't test yet that we can read it back from a text file
-    atom.save_metadata('local_metadata.txt')
+    metadata.save_metadata('local_metadata.txt')
     # Then test that we can get all the metadata
-    my_metadata = atom.get_all_metadata()
+    my_metadata = metadata.get_all_metadata()
     # Now test that we can load the metadata
-    atom.read_metadata('local_metadata.json')
+    metadata.read_metadata('local_metadata.json')
     # Check the new metadata
-    assert my_metadata == atom.get_all_metadata()
+    assert my_metadata == metadata.get_all_metadata()
 
     # Test behavior when a non-standard file type is requested for metadata saving.
     with pytest.raises(ValueError):
-        atom.save_metadata('local_metadata.csv')
+        metadata.save_metadata('local_metadata.csv')
 
     # Test a bad metadata load
     import json
     with open('test_file.json','w') as test_json:
         json.dump( ['list','of','things'], test_json)
     with pytest.raises(ValueError):
-        atom.read_metadata('test_file.json')
+        metadata.read_metadata('test_file.json')
 
     # Clean up after ourselves
     import os
@@ -406,7 +406,7 @@ def test_save_read_metadata():
     os.remove('local_metadata.txt')
 
     # Ensure the cache is cleared
-    atom.set_release('2024r-pp')
+    metadata.set_release('2024r-pp')
 
 def test_get_all_metadata():
     """
@@ -416,7 +416,7 @@ def test_get_all_metadata():
     from atlasopenmagic import metadata
     metadata.empty_metadata()
     # Then test that we can get all the metadata
-    my_metadata = atom.get_all_metadata()
+    my_metadata = metadata.get_all_metadata()
 
 def test_internals():
     """

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -378,26 +378,26 @@ def test_save_read_metadata():
     metadata.empty_metadata()
 
     # First test that we can save the metadata
-    metadata.save_metadata('local_metadata.json')
+    atom.save_metadata('local_metadata.json')
     # Write it to a text file as well - we don't test yet that we can read it back from a text file
-    metadata.save_metadata('local_metadata.txt')
+    atom.save_metadata('local_metadata.txt')
     # Then test that we can get all the metadata
-    my_metadata = metadata.get_all_metadata()
+    my_metadata = atom.get_all_metadata()
     # Now test that we can load the metadata
-    metadata.read_metadata('local_metadata.json')
+    atom.read_metadata('local_metadata.json')
     # Check the new metadata
-    assert my_metadata == metadata.get_all_metadata()
+    assert my_metadata == atom.get_all_metadata()
 
     # Test behavior when a non-standard file type is requested for metadata saving.
     with pytest.raises(ValueError):
-        metadata.save_metadata('local_metadata.csv')
+        atom.save_metadata('local_metadata.csv')
 
     # Test a bad metadata load
     import json
     with open('test_file.json','w') as test_json:
         json.dump( ['list','of','things'], test_json)
     with pytest.raises(ValueError):
-        metadata.read_metadata('test_file.json')
+        atom.read_metadata('test_file.json')
 
     # Clean up after ourselves
     import os
@@ -406,7 +406,7 @@ def test_save_read_metadata():
     os.remove('local_metadata.txt')
 
     # Ensure the cache is cleared
-    metadata.set_release('2024r-pp')
+    atom.set_release('2024r-pp')
 
 def test_get_all_metadata():
     """
@@ -416,7 +416,7 @@ def test_get_all_metadata():
     from atlasopenmagic import metadata
     metadata.empty_metadata()
     # Then test that we can get all the metadata
-    my_metadata = metadata.get_all_metadata()
+    my_metadata = atom.get_all_metadata()
 
 def test_internals():
     """

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -366,14 +366,16 @@ def test_find_all_files():
     assert atom.get_urls("data") == ["root://eospublic.cern.ch:1094//eos/path/to/ttbar.root"]
     assert atom.get_urls("data", skim="4lep") == ["/fake/path/mock_data1/4lep_skim_data.root"]
 
-    # atom.set_release('2025e-13tev-beta')  # Reset to the original release
+    # Ensure that the cache is cleared
     atom.set_release('2024r-pp')  # Reset to the original release
-
 
 def test_save_read_metadata():
     """
     Test that we can save metadata to a json file and read it back, and get back what we wrote
     """
+    # Ensure the cache is cleared
+    atom.set_release('2024r-pp')
+
     # First test that we can save the metadata
     atom.save_metadata('local_metadata.json')
     # Write it to a text file as well - we don't test yet that we can read it back from a text file
@@ -409,6 +411,9 @@ def test_get_all_metadata():
     """
     Test function to get all metadata without a warm cache
     """
+    # Ensure the cache is cleared
+    atom.set_release('2024r-pp')
+
     # Then test that we can get all the metadata
     my_metadata = atom.get_all_metadata()
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -139,6 +139,11 @@ def test_get_metadata_no_cache(mock_api):
 
 def test_get_metadata_full():
     """Test retrieving the full metadata dictionary for a dataset by its number."""
+    # Empty out the cache first
+    from atlasopenmagic import metadata
+    metadata.empty_metadata()
+
+    # Grab the metadata for the specific dataset
     metadata = atom.get_metadata("301204")
     assert metadata is not None
     assert metadata["dataset_number"] == "301204"
@@ -261,12 +266,21 @@ def test_install_from_environment():
 
 def test_available_datasets():
     """Test that available_datasets returns the correct, sorted list of dataset numbers."""
+    # Empty out the cache first
+    from atlasopenmagic import metadata
+    metadata.empty_metadata()
+
+    # Now see what datasets are available to us
     data = atom.available_datasets()
     assert data == ['301204', '410470', 'data']
 
 def test_available_keywords():
     """Test that available_keywords returns the correct list of keywords."""
-    
+    # Empty out the cache first
+    from atlasopenmagic import metadata
+    metadata.empty_metadata()
+
+    # Now check our available keywords
     keywords = atom.available_keywords()
     assert isinstance(keywords, list)
     assert "2electron" in keywords
@@ -276,6 +290,9 @@ def test_available_keywords():
 
 def test_match_metadata():
     """Test that match_metadata returns the correct metadata for a given keyword."""
+    # Empty out the cache before the first call to check the caching functionality
+    from atlasopenmagic import metadata
+    metadata.empty_metadata()
 
     # Match datasets_numbers
     matched = atom.match_metadata("dataset_number", "301204")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -396,6 +396,12 @@ def test_save_read_metadata():
     with pytest.raises(ValueError):
         atom.read_metadata('test_file.json')
 
+    # Clean up after ourselves
+    import os
+    os.remove('test_file.json')
+    os.remove('local_metadata.json')
+    os.remove('local_metadata.txt')
+
     # Ensure the cache is cleared
     atom.set_release('2024r-pp')
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -395,3 +395,23 @@ def test_save_read_metadata():
         json.dump( ['list','of','things'], test_json)
     with pytest.raises(ValueError):
         atom.read_metadata('test_file.json')
+
+
+def test_get_all_metadata():
+    """
+    Test function to get all metadata without a warm cache
+    """
+    # Then test that we can get all the metadata
+    my_metadata = atom.get_all_metadata()
+
+
+def test_internals():
+    """
+    Test internal functions from atlasopenmagic
+    """
+    from atlasopenmagic import metadata
+    test_path = "/fake/path/mock_data/noskim_301204.root"
+    # Check that if we don't give a current local path we just get our path back
+    assert metadata._convert_to_local(test_path) == "/fake/path/mock_data/noskim_301204.root"
+    # Check that if we start with our local path, we just get our path back
+    assert metadata._convert_to_local(test_path,'/fake/path') == "/fake/path/mock_data/noskim_301204.root"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -368,3 +368,19 @@ def test_find_all_files():
 
     # atom.set_release('2025e-13tev-beta')  # Reset to the original release
     atom.set_release('2024r-pp')  # Reset to the original release
+
+
+def test_save_read_metadata():
+    """
+    Test that we can save metadata to a json file and read it back, and get back what we wrote
+    """
+    # First test that we can save the metadata
+    atom.save_metadata('local_metadata.json')
+    # Write it to a text file as well - we don't test yet that we can read it back from a text file
+    atom.save_metadata('local_metadata.txt')
+    # Then test that we can get all the metadata
+    my_metadata = atom.get_all_metadata()
+    # Now test that we can load the metadata
+    atom.read_metadata('local_metadata.json')
+    # Check the new metadata
+    assert my_metadata == atom.get_all_metadata()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -384,3 +384,14 @@ def test_save_read_metadata():
     atom.read_metadata('local_metadata.json')
     # Check the new metadata
     assert my_metadata == atom.get_all_metadata()
+
+    # Test behavior when a non-standard file type is requested for metadata saving.
+    with pytest.raises(ValueError):
+        atom.save_metadata('local_metadata.csv')
+
+    # Test a bad metadata load
+    import json
+    with open('test_file.json','w') as test_json:
+        json.dump( ['list','of','things'], test_json)
+    with pytest.raises(ValueError):
+        atom.read_metadata('test_file.json')


### PR DESCRIPTION
Implements get_all_metadata: easy pass-through for getting the entire metadata dictionary in a public function, since at the moment it's an internal variable

Implements save_metadata: function for saving metadata in an output file; currently implemented for txt and json

Implements read_metadata: function for reading metadata from an input file; currently implemented for json

Adds a test that covers all of the above.

Closes #41 