### PR TITLE
Adding type hints, completing test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -33,7 +33,7 @@ import warnings
 import requests
 from requests.exceptions import HTTPError
 # Some functions (like metadata) can return any type
-from typing import Any
+from typing import Optional, Any
 
 # --- Global Configuration & State ---
 
@@ -220,7 +220,7 @@ def get_current_release() -> str:
 
 
 def _convert_to_local(url: str,
-                      current_local_path: str | None = None) -> str:
+                      current_local_path: Optional[str] = None) -> str:
     """Convert to a local file path if one is set for the current release."""
     if not current_local_path:
         return url  # No local mode active
@@ -238,7 +238,7 @@ def _convert_to_local(url: str,
 
 
 def set_release(release: str,
-                local_path: str | None = None) -> None:
+                local_path: Optional[str] = None) -> None:
     """
     Sets the active data release for all subsequent API calls.
 
@@ -393,7 +393,7 @@ def find_all_files(local_path: str,
 
 
 def get_all_info(key: str,
-                 var: str | None = None,
+                 var: Optional[str] = None,
                  cache: bool = True) -> Any:
     """
     Retrieves all the information for a given dataset,
@@ -464,7 +464,7 @@ def get_all_info(key: str,
 
 
 def get_metadata(key: str,
-                 var: str | None = None,
+                 var: Optional[str] = None,
                  cache: bool = True) -> Any:
     """
     Retrieves the metadata (no file lists) for a given dataset, identified by its number or physics short name.

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -32,6 +32,8 @@ import threading
 import warnings
 import requests
 from requests.exceptions import HTTPError
+# Some functions (like metadata) can return any type
+from typing import Any
 
 # --- Global Configuration & State ---
 
@@ -115,7 +117,8 @@ AVAILABLE_FIELDS = [
 # --- Internal Helper Functions ---
 
 
-def _apply_protocol(url, protocol):
+def _apply_protocol(url: str,
+                    protocol: str) -> str:
     """
     Internal helper to transform a root URL into the specified protocol format.
 
@@ -140,7 +143,7 @@ def _apply_protocol(url, protocol):
     )
 
 
-def _fetch_and_cache_release_data(release_name):
+def _fetch_and_cache_release_data(release_name: str) -> str:
     """
     Internal helper to fetch all datasets for a release and populate the local cache.
     This function performs a single, efficient API call to `/releases/{release_name}`
@@ -187,7 +190,7 @@ def _fetch_and_cache_release_data(release_name):
 # --- Public API Functions ---
 
 
-def available_releases():
+def available_releases() -> dict[str,tuple[str] ]:
     """
     Displays a list of all available data releases and their descriptions,
     with clean, aligned formatting.
@@ -206,7 +209,7 @@ def available_releases():
     return RELEASES_DESC
 
 
-def get_current_release():
+def get_current_release() -> str:
     """
     Returns the name of the currently active data release.
 
@@ -216,7 +219,8 @@ def get_current_release():
     return current_release
 
 
-def _convert_to_local(url, current_local_path=None):
+def _convert_to_local(url: str,
+                      current_local_path: str | None = None) -> str:
     """Convert to a local file path if one is set for the current release."""
     if not current_local_path:
         return url  # No local mode active
@@ -233,7 +237,8 @@ def _convert_to_local(url, current_local_path=None):
     return os.path.join(current_local_path, rel)
 
 
-def set_release(release, local_path=None):
+def set_release(release: str,
+                local_path: str | None = None) -> None:
     """
     Sets the active data release for all subsequent API calls.
 
@@ -279,7 +284,8 @@ def set_release(release, local_path=None):
     )
 
 
-def find_all_files(local_path, warnmissing=False):
+def find_all_files(local_path: str,
+                   warnmissing: bool = False) -> None:
     """
     Replace cached remote URLs in `_metadata` with corresponding local file paths
     if those files exist in the given `local_path`.
@@ -386,7 +392,9 @@ def find_all_files(local_path, warnmissing=False):
     )
 
 
-def get_all_info(key, var=None, cache=True):
+def get_all_info(key: str,
+                 var: str | None = None,
+                 cache: bool = True) -> Any:
     """
     Retrieves all the information for a given dataset,
     identified by its number or physics short name.
@@ -455,7 +463,9 @@ def get_all_info(key, var=None, cache=True):
     )
 
 
-def get_metadata(key, var=None, cache=True):
+def get_metadata(key: str,
+                 var: str | None = None,
+                 cache: bool = True) -> Any:
     """
     Retrieves the metadata (no file lists) for a given dataset, identified by its number or physics short name.
 
@@ -480,7 +490,10 @@ def get_metadata(key, var=None, cache=True):
     return all_info
 
 
-def get_urls(key, skim="noskim", protocol="root", cache=False):
+def get_urls(key: str,
+             skim: str = "noskim",
+             protocol: str = "root",
+             cache: bool = False) -> list[str]:
     """
     Retrieves file URLs for a given dataset, with options for skims and protocols.
 
@@ -553,7 +566,7 @@ def get_urls(key, skim="noskim", protocol="root", cache=False):
     return final_urls
 
 
-def available_datasets():
+def available_datasets() -> list[str]:
     """
     Returns a sorted list of all available dataset numbers for the current release.
 
@@ -569,7 +582,7 @@ def available_datasets():
     return sorted([k for k in _metadata if k.isdigit() or k == "data"])
 
 
-def get_all_metadata():
+def get_all_metadata() -> dict[str,dict]:
     """
     Returns the entire metadata dictionary, en mass
     Returns:
@@ -582,7 +595,7 @@ def get_all_metadata():
     return _metadata
 
 
-def empty_metadata():
+def empty_metadata() -> None:
     """
     Internal helper function to empty the metadata cache and leave it empty
     """
@@ -596,7 +609,7 @@ def empty_metadata():
 # --- Metadata search functions
 
 
-def available_keywords():
+def available_keywords() -> list[str]:
     """
     Returns a sorted list of available keywords in use in the current release
 
@@ -621,7 +634,9 @@ def available_keywords():
     return sorted(keyword_list)
 
 
-def match_metadata(field, value, float_tolerance=0.01):
+def match_metadata(field: str,
+                   value: Any,
+                   float_tolerance: float = 0.01) -> list[tuple[str,str]]:
     """
     Returns a sorted list of datasets with metadata field matching value
 
@@ -673,7 +688,7 @@ def match_metadata(field, value, float_tolerance=0.01):
 # --- Metadata saving and loading functions ---
 
 
-def save_metadata(file_name='metadata.json'):
+def save_metadata(file_name: str = 'metadata.json') -> None:
     """
     Save the metadata in an output file.
     Attempts to adjust the output based on the file extension, currently supporting txt and json.
@@ -712,7 +727,8 @@ def save_metadata(file_name='metadata.json'):
     else:
         raise ValueError(f'Requested metadata saving to unsupported filetype: {file_name.split(".")[-1]}. Currently supporting txt and json.')
 
-def read_metadata(file_name='metadata.json', release='custom'):
+def read_metadata(file_name: str = 'metadata.json',
+                  release: str = 'custom') -> None:
     """
     Reads the metadata from an input file.
     Overwrites existing metadata.
@@ -744,7 +760,8 @@ def read_metadata(file_name='metadata.json', release='custom'):
 # --- Deprecated Functions (for backward compatibility) ---
 
 
-def get_urls_data(key, protocol="root"):
+def get_urls_data(key: str,
+                  protocol: str = "root") -> list[str]:
     """
     DEPRECATED: Retrieves file URLs for the base (unskimmed) dataset.
 

--- a/atlasopenmagic/metadata.py
+++ b/atlasopenmagic/metadata.py
@@ -654,8 +654,8 @@ def match_metadata(field, value, float_tolerance=0.01):
                 if abs(float(value) - metadata[field]) / float(value) < float_tolerance:
                     matches += [k]
             # For other field types require an exact match
-            elif value == metadata[field]:  # pragma no cover
-                matches += [k]              # pragma no cover
+            elif value == metadata[field]:
+                matches += [k]
         # Allow people to search for empty metadata fields
         elif (field not in metadata or metadata[field] is None) and value is None:
             matches += [k]

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -15,7 +15,7 @@ import requests
 from atlasopenmagic.metadata import get_urls
 
 
-def install_from_environment(*packages: list[str] | None,
+def install_from_environment(*packages: str | None,
                              environment_file: str | None = None) -> None: # pragma: no cover
     """
     Install specific packages listed in an environment.yml file via pip.

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -13,10 +13,11 @@ from pathlib import Path
 import yaml
 import requests
 from atlasopenmagic.metadata import get_urls
+from typing import Optional
 
 
-def install_from_environment(*packages: str | None,
-                             environment_file: str | None = None) -> None: # pragma: no cover
+def install_from_environment(*packages: Optional[str],
+                             environment_file: Optional[str] = None) -> None: # pragma: no cover
     """
     Install specific packages listed in an environment.yml file via pip.
 
@@ -175,7 +176,7 @@ def build_dataset(samples_defs: dict[str,dict],
 
 def build_data_dataset(data_keys: list[str],
                        name: str = "Data",
-                       color: str | None = None,
+                       color: Optional[str] = None,
                        protocol: str = "https",
                        cache: bool = False) -> dict[str,dict]:
     """

--- a/atlasopenmagic/utils.py
+++ b/atlasopenmagic/utils.py
@@ -15,7 +15,8 @@ import requests
 from atlasopenmagic.metadata import get_urls
 
 
-def install_from_environment(*packages, environment_file=None): # pragma: no cover
+def install_from_environment(*packages: list[str] | None,
+                             environment_file: str | None = None) -> None: # pragma: no cover
     """
     Install specific packages listed in an environment.yml file via pip.
 
@@ -143,7 +144,10 @@ def install_from_environment(*packages, environment_file=None): # pragma: no cov
         )
 
 
-def build_dataset(samples_defs, skim="noskim", protocol="https", cache=False):
+def build_dataset(samples_defs: dict[str,dict],
+                  skim: str = "noskim",
+                  protocol: str = "https",
+                  cache=False) -> dict[str,dict]:
     """
     Build a dict of MC samples URLs.
 
@@ -169,9 +173,11 @@ def build_dataset(samples_defs, skim="noskim", protocol="https", cache=False):
     return out
 
 
-def build_data_dataset(
-    data_keys, name="Data", color=None, protocol="https", cache=False
-):
+def build_data_dataset(data_keys: list[str],
+                       name: str = "Data",
+                       color: str | None = None,
+                       protocol: str = "https",
+                       cache: bool = False) -> dict[str,dict]:
     """
     Build a dataset for data samples.
     This function is deprecated and will be removed in future versions.
@@ -196,7 +202,10 @@ def build_data_dataset(
     )
 
 
-def build_mc_dataset(mc_defs, skim="noskim", protocol="https", cache=False):
+def build_mc_dataset(mc_defs: dict[str,dict],
+                     skim: str = "noskim",
+                     protocol: str = "https",
+                     cache: bool = False) -> dict[str,dict]:
     """
     Build a dict of MC samples URLs.
     This function is deprecated and will be removed in future versions.

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -445,3 +445,21 @@ def test_internals():
     assert metadata._convert_to_local(test_path) == "/fake/path/mock_data/noskim_301204.root"
     # Check that if we start with our local path, we just get our path back
     assert metadata._convert_to_local(test_path,'/fake/path') == "/fake/path/mock_data/noskim_301204.root"
+
+def test_other_metadata_field_type():
+    """
+    When loading custom metadata, it is possible that someone has a field that's a type we don't treat.
+    This checks what happens in that case.
+    """
+    # Write ourselves a little test file with differently-valued metadata
+    import json
+    with open('test_file.json','w') as test_json:
+        json.dump( {'123456':{'test':{'content':'value'},'physics_short':'test_sample'}}, test_json)
+    atom.read_metadata('test_file.json')
+    # Cleanliness is important!
+    import os
+    os.remove('test_file.json')
+    # Now try to get the metadata based on the keyword
+    assert atom.match_metadata('test', {'content':'value'}) == [('123456', 'test_sample')]
+    # Now try to get metadata for a field we don't use
+    assert atom.match_metadata('not_a_field',None) == [('123456', 'test_sample')]


### PR DESCRIPTION
Closes #38
    
Adding type hints to all the functions in metadata and utils
    
In Python 3.9, we can't use the `str | None` style specification for
    optional arguments; we instead have to use `Optional`. It feels to me
    like it is not worth cutting up our code base to retain support for
    python 3.9. On the other hand (annoyingly), lxplus still uses python 3.9
    by default, so this means folks need a non-standard version of python
    out of the box to run on lxplus. I'm not sure what's best here, but this
    is a version submitted for your consideration.

[edit: Python 3.9 syntax is also supported in newer releases, so just switching to that so that we can keep 3.9 in]
    
In the meantime, this PR will also complete our test coverage.