### PR TITLE
Adding more documentation to the modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,3 @@ ignore = []
 
 [tool.pydocstyle]
 convention = "google"
-add-ignore = "D100,D104"  # Missing docstring in public module/package

--- a/src/atlasopenmagic/__init__.py
+++ b/src/atlasopenmagic/__init__.py
@@ -1,6 +1,8 @@
 """This module initializes the atlasopenmagic package.
 
-It provides access to its functionalities.
+It provides access to its functionalities. All functions
+are exposed at the module level, so direct use of the
+metadata or utils modules should not be required.
 """
 
 from .metadata import (

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+"""This includes tests for the atlasopenmagic package.
+
+The `__init__.py` file is required for pytest to correctly
+identify the tests in the package. More documentation is
+in `test_metadata.py`.
+"""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,13 @@
+"""This file provides tests for the atlasopenmagic package.
+
+Tests use the unittest.mock functionality to avoid relying on
+database access when running. The `MOCK_API_RESPONSE` should be
+updated when adding new functionality that should be tested.
+Tests generally focus on one aspect of functionality, but often
+test several code branches with a single function. Tests are
+named in a way that identifies the function they are testing.
+"""
+
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Adds docstrings everywhere they were missing (there were not many missing). We no longer need to ignore D100 or D104.

Closes #53.