### PR TITLE
Let build_dataset return a dictionary which can be used to define an RDataFrame

### DIFF
--- a/src/atlasopenmagic/__init__.py
+++ b/src/atlasopenmagic/__init__.py
@@ -26,6 +26,7 @@ from .metadata import (
     set_verbosity,
 )
 from .utils import (
+    build_RDFspec,
     build_data_dataset,
     build_dataset,
     build_mc_dataset,
@@ -53,6 +54,7 @@ __all__ = [
     "read_metadata",
     "get_all_metadata",
     "install_from_environment",
+    "build_RDFspec",
     "build_dataset",
     "build_mc_dataset",
     "build_data_dataset",

--- a/src/atlasopenmagic/__init__.py
+++ b/src/atlasopenmagic/__init__.py
@@ -26,7 +26,6 @@ from .metadata import (
     set_verbosity,
 )
 from .utils import (
-    build_RDFspec,
     build_data_dataset,
     build_dataset,
     build_mc_dataset,
@@ -54,7 +53,6 @@ __all__ = [
     "read_metadata",
     "get_all_metadata",
     "install_from_environment",
-    "build_RDFspec",
     "build_dataset",
     "build_mc_dataset",
     "build_data_dataset",

--- a/src/atlasopenmagic/utils.py
+++ b/src/atlasopenmagic/utils.py
@@ -17,6 +17,7 @@ import requests
 import yaml
 
 from atlasopenmagic.metadata import get_urls
+from atlasopenmagic.metadata import get_metadata, get_current_release
 
 
 def install_from_environment(
@@ -152,6 +153,7 @@ def build_dataset(
     skim: str = "noskim",
     protocol: str = "https",
     cache: Optional[bool] = False,
+    rdf: Optional[bool] = False,
 ) -> dict[str, dict]:
     r"""Build a dict of MC samples URLs.
 
@@ -165,6 +167,9 @@ def build_dataset(
         cache: Use the simplecache mechanism of fsspec to locally cache
             files instead of streaming them. Default False means let
             atlasopenmagic decide what to do for that protocol.
+        rdf: Return a dictionary compatible with ROOT's ROOT.RDF.Experimental.FromSpec()
+            function used to define an RDataFrame with all the metadata needed to perform an analysis
+            on the Open Data
     Example:
     ```python
     import atlasopenmagic as atom
@@ -181,19 +186,53 @@ def build_dataset(
 
     Returns:
         A dictionary containing sample names as keys and dictionaries with 'list' of URLs
-        and optional 'color' as values.
+        and optional 'color' as values. If rdf=True it returns a dictionary on a form compatible with
+        ROOT.RDF.Experimental.FromSpec().
     """
-    out = {}
+    if not rdf:
+        out = {}
+        for name, info in samples_defs.items():
+            urls = []
+            for did in info["dids"]:
+                urls.extend(get_urls(str(did), skim=skim, protocol=protocol, cache=cache))
+            sample = {"list": urls}
+            if "color" in info:
+                sample["color"] = info["color"]
+            out[name] = sample
+        return out
+
+    out = {"samples":{}}
+    import os
+    cr = get_current_release()
+    print("----->Current release",cr)
+    treenames = {"2024r-pp":"CollectionTree",
+                 "2024r-hi":"CollectionTree",
+                 "2025e-13tev-beta":"analysis",
+                 "2016e-8tev":"mini",
+                 "2020e-13tev":"mini"
+                 }
+    if not cr in treenames.keys():
+        raise ValueError("Release can not be read with ROOT's RDataFrame. Compatible releases are %s"%"\n".join(treenames.keys()))
     for name, info in samples_defs.items():
         urls = []
+        metadata = {'xsec': 1.0,
+                    'sumOfWeights': 1.0,
+                    'genFiltEff': 1.0,
+                    'kFactor': 1.0,
+                    'proc': name,
+                    'color': info["color"]}
         for did in info["dids"]:
-            urls.extend(get_urls(str(did), skim=skim, protocol=protocol, cache=cache))
-        sample = {"list": urls}
-        if "color" in info:
-            sample["color"] = info["color"]
-        out[name] = sample
+            if not "data" in did:
+                metadata['xsec'] = get_metadata(did,'cross_section_pb')
+                metadata['sumOfWeights'] = get_metadata(did,'sumOfWeights')
+                metadata['genFiltEff'] = get_metadata(did,'genFiltEff')
+                metadata['kFactor'] = get_metadata(did,'kFactor')            
+                out['samples'][did] = {"trees":[treenames[cr]],
+                                       "files":[item for item in get_urls(str(did), skim=skim, protocol=protocol, cache=False)],
+                                       "metadata":metadata}
+        
+    
     return out
-
 
 def build_data_dataset(
     data_keys: list[str],

--- a/src/atlasopenmagic/utils.py
+++ b/src/atlasopenmagic/utils.py
@@ -16,8 +16,7 @@ from typing import Any, Optional
 import requests
 import yaml
 
-from atlasopenmagic.metadata import get_urls
-from atlasopenmagic.metadata import get_metadata, get_current_release
+from .metadata import get_current_release, get_metadata, get_urls
 
 
 def install_from_environment(
@@ -201,38 +200,40 @@ def build_dataset(
             out[name] = sample
         return out
 
-    out = {"samples":{}}
-    import os
+    out = {"samples": {}}
+
     cr = get_current_release()
-    print("----->Current release",cr)
-    treenames = {"2024r-pp":"CollectionTree",
-                 "2024r-hi":"CollectionTree",
-                 "2025e-13tev-beta":"analysis",
-                 "2016e-8tev":"mini",
-                 "2020e-13tev":"mini"
-                 }
-    if not cr in treenames.keys():
-        raise ValueError("Release can not be read with ROOT's RDataFrame. Compatible releases are %s"%"\n".join(treenames.keys()))
+    treenames = {
+        "2024r-pp": "CollectionTree",
+        "2024r-hi": "CollectionTree",
+        "2025e-13tev-beta": "analysis",
+        "2016e-8tev": "mini",
+        "2020e-13tev": "mini",
+    }
     for name, info in samples_defs.items():
         urls = []
-        metadata = {'xsec': 1.0,
-                    'sumOfWeights': 1.0,
-                    'genFiltEff': 1.0,
-                    'kFactor': 1.0,
-                    'proc': name,
-                    'color': info["color"]}
+        metadata = {
+            "xsec": 1.0,
+            "sumOfWeights": 1.0,
+            "genFiltEff": 1.0,
+            "kFactor": 1.0,
+            "proc": name,
+            "color": info["color"],
+        }
         for did in info["dids"]:
-            if not "data" in did:
-                metadata['xsec'] = get_metadata(did,'cross_section_pb')
-                metadata['sumOfWeights'] = get_metadata(did,'sumOfWeights')
-                metadata['genFiltEff'] = get_metadata(did,'genFiltEff')
-                metadata['kFactor'] = get_metadata(did,'kFactor')            
-                out['samples'][did] = {"trees":[treenames[cr]],
-                                       "files":[item for item in get_urls(str(did), skim=skim, protocol=protocol, cache=False)],
-                                       "metadata":metadata}
-        
-    
+            if "data" not in did:
+                metadata["xsec"] = get_metadata(did, "cross_section_pb")
+                metadata["sumOfWeights"] = get_metadata(did, "sumOfWeights")
+                metadata["genFiltEff"] = get_metadata(did, "genFiltEff")
+                metadata["kFactor"] = get_metadata(did, "kFactor")
+            out["samples"][did] = {
+                "trees": [treenames[cr]],
+                "files": list(get_urls(str(did), skim=skim, protocol=protocol, cache=False)),
+                "metadata": metadata,
+            }
+
     return out
+
 
 def build_data_dataset(
     data_keys: list[str],

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -109,8 +109,57 @@ MOCK_DATASETS_2020 = [
     }
 ]
 
+# Add mock datasets for the "2025e-13tev-beta" release
+MOCK_DATASETS_2025 = [
+    {
+        "dataset_number": "301204",
+        "physics_short": "Pythia8EvtGen_A14MSTW2008LO_Zprime_NoInt_ee_SSM3000",
+        "e_tag": "e3723",
+        "cross_section_pb": 0.001762,
+        "genFiltEff": 1.0,
+        "kFactor": 1.0,
+        "nEvents": 20000,
+        "sumOfWeights": 20000.0,
+        "sumOfWeightsSquared": 20000.0,
+        "process": "pp>Zprime>ee",
+        "generator": "Pythia8(v8.186)+EvtGen(v1.2.0)",
+        "keywords": ["2electron", "BSM", "SSM"],
+        "file_list": ["root://eospublic.cern.ch:1094//eos/path/to/noskim_301204.root"],
+        "description": "Pythia 8 Zprime decaying to two electrons'",
+        "job_path": "https://gitlab.cern.ch/path/to/job/options",
+        "release": {"name": "2025e-13tev-beta"},
+        "skims": [
+            {
+                "id": 1,
+                "skim_type": "4lep",
+                "file_list": ["root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_301204.root"],
+                "description": "Exactly 4 leptons",
+                "dataset_number": "301204",
+                "release_name": "2025e-13tev-beta",
+            }
+        ],
+    },
+    {
+        "dataset_number": "data",
+        "physics_short": None,
+        "cross_section_pb": 831.76,
+        "file_list": ["root://eospublic.cern.ch:1094//eos/path/to/ttbar.root"],
+        "skims": [
+            {
+                "id": 1,
+                "skim_type": "4lep",
+                "file_list": ["root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_data.root"],
+                "description": "Exactly 4 leptons",
+                "dataset_number": "data",
+                "release_name": "2025e-13tev-beta",
+            }
+        ],
+        "release": {"name": "2025e-13tev-beta"},
+    },
+]
+
 # Combine all datasets for easier access
-ALL_MOCK_DATASETS = MOCK_DATASETS + MOCK_DATASETS_2020
+ALL_MOCK_DATASETS = MOCK_DATASETS + MOCK_DATASETS_2020 + MOCK_DATASETS_2025
 
 
 @pytest.fixture(autouse=True)
@@ -130,6 +179,8 @@ def mock_api():
             active_datasets = MOCK_DATASETS_2020
         elif release_filter == "2024r-pp":
             active_datasets = MOCK_DATASETS
+        elif release_filter == "2025e-13tev-beta":
+            active_datasets = MOCK_DATASETS_2025
         else:
             active_datasets = ALL_MOCK_DATASETS
 
@@ -153,6 +204,8 @@ def mock_api():
                     search_datasets = MOCK_DATASETS_2020
                 elif release_name == "2024r-pp":
                     search_datasets = MOCK_DATASETS
+                elif release_name == "2025e-13tev-beta":
+                    search_datasets = MOCK_DATASETS_2025
                 else:
                     search_datasets = ALL_MOCK_DATASETS
 
@@ -648,17 +701,21 @@ def test_build_dataset():
     atom.set_release("2025e-13tev-beta")
     dataset = atom.build_dataset(sample_defs, skim="4lep", protocol="root", rdf=True)
 
-    
     # Check URLs for Sample1
     print(dataset["samples"])  # For debugging purposes
-    assert dataset["samples"]["301204"]["files"] == ["root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_301204.root"]
+    assert dataset["samples"]["301204"]["files"] == [
+        "root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_301204.root"
+    ]
     assert dataset["samples"]["301204"]["metadata"]["color"] == "blue"
     assert dataset["samples"]["301204"]["trees"] == ["analysis"]
 
     # Check URLs for Sample2
-    assert dataset["samples"]["data"]["files"] == ["root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_data.root"]
+    assert dataset["samples"]["data"]["files"] == [
+        "root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_data.root"
+    ]
     assert dataset["samples"]["data"]["metadata"]["color"] == "red"
     assert dataset["samples"]["data"]["trees"] == ["analysis"]
+
 
 def test_find_all_files():
     """
@@ -800,7 +857,9 @@ def test_count_endpoint_mock():
 
     # Test without release filter
     response_all = session.get(f"{md.API_BASE_URL}/datasets/count", timeout=30)
-    assert response_all.json()["count"] == 5  # ALL_MOCK_DATASETS has 5 (4 + 1 from 2020)
+    assert (
+        response_all.json()["count"] == 7
+    )  # ALL_MOCK_DATASETS has 7 (4 from 2024r-pp + 1 from 2020 + 2 from 2025)
 
 
 def test_fetch_and_cache_handles_count_error():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -613,6 +613,7 @@ def test_build_dataset():
     from src.atlasopenmagic import metadata as md
 
     md._session = None
+    atom.set_release("2025e-13tev-beta")
 
     # Original test code
     sample_defs = {
@@ -643,6 +644,21 @@ def test_build_dataset():
         dataset = atom.build_data_dataset("4lep")
         dataset = atom.build_mc_dataset(samples_defs_deprecated)
 
+    # Build the dataset
+    atom.set_release("2025e-13tev-beta")
+    dataset = atom.build_dataset(sample_defs, skim="4lep", protocol="root", rdf=True)
+
+    
+    # Check URLs for Sample1
+    print(dataset["samples"])  # For debugging purposes
+    assert dataset["samples"]["301204"]["files"] == ["root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_301204.root"]
+    assert dataset["samples"]["301204"]["metadata"]["color"] == "blue"
+    assert dataset["samples"]["301204"]["trees"] == ["analysis"]
+
+    # Check URLs for Sample2
+    assert dataset["samples"]["data"]["files"] == ["root://eospublic.cern.ch:1094//eos/path/to/4lep_skim_data.root"]
+    assert dataset["samples"]["data"]["metadata"]["color"] == "red"
+    assert dataset["samples"]["data"]["trees"] == ["analysis"]
 
 def test_find_all_files():
     """


### PR DESCRIPTION
Adding an option, `rdf`, to `build_dataset`. If set to True the build_dataset function returns a dictionary on the form described in the [RDataFrame documentation](https://root.cern/doc/master/classROOT_1_1RDataFrame.html#rdf-from-spec). It can be used with `ROOT.RDF.Experimental.FromSpec("spec.json")` to define a RDataFrame and gives you automatically access to the metadata needed to perform an analysis using ROOT's RDataFrame.

Note that the fsspec simplecache mechanism is not compatible with ROOT's RDataFrame (afaik) and thus cache is set to False in the get_urls.

If option `rdf` is not specified or set to False the returned dictionary is on the same format as before.  