### PR TITLE
surprise: add CLI interface and PyPI update check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ And get the URLs for the one that's to be used:
 all_mc = atom.get_urls('data')
 ```
 
+## Command-line interface
+Installing the package also installs a CLI, available as both `atlasopenmagic` and the shorter `atom`. It covers the read-only lookups (metadata, URLs, weights) and prints JSON to stdout, so it composes well with tools like `jq` or with shell scripts:
+```bash
+atom --release 2024r-pp metadata 301204 --field cross_section_pb
+atom urls 301204 --skim exactly4lep --protocol https
+atom search process "pp>Zprime>ee"
+atom weights 301204
+```
+Run `atom --help` or `atom <command> --help` for the full list of commands and options. Since it wraps read-only lookups, it doesn't cover functions with local side effects or that return non-serializable Python objects (`build_dataset`, `install_from_environment`, etc.) — use the Python API for those.
+
+The CLI checks PyPI at most once a day for a newer release and prints a short notice to stderr if one is available; it never runs on a plain `import atlasopenmagic`. Disable it with `--no-update-check` or by setting `ATLASOPENMAGIC_NO_UPDATE_CHECK=1`.
+
 
 ## Contributing
 Contributions are welcome! To contribute:

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ all_mc = atom.get_urls('data')
 ```
 
 ## Command-line interface
-Installing the package also installs a CLI, available as both `atlasopenmagic` and the shorter `atom`. It follows a `atom <group> <command> [arguments] [options]` layout and prints JSON to stdout, so it composes well with tools like `jq` or with shell scripts.
+Installing the package also installs a CLI, available as both `atlasopenmagic` and the shorter `atom`. The two are the same program, so if `atom` clashes with something else on your machine, `atlasopenmagic` always works and can be aliased to whatever you prefer. It follows a `atom <group> <command> [arguments] [options]` layout and prints JSON to stdout, so it composes well with tools like `jq` or with shell scripts.
 
-Pick a release once, then query without repeating yourself:
+Pick a release once, then query without having to repeat yourself:
 ```bash
 atom release set 2024r-pp
 atom dataset show 301204 --field cross_section_pb
@@ -93,6 +93,8 @@ atom dataset search process "pp>Zprime>ee"            # not valid JSON, so plain
 atom dataset search keywords 2024 --raw               # force text for a numeric-looking value
 ```
 
+Quote lists and objects, or the shell will take them apart before `atom` ever sees them: `zsh` reads the brackets as a filename pattern and refuses to run the command, while `bash` strips the inner quotes and hands over `[2electron,BSM]`, which is no longer valid JSON. The CLI warns when it receives a value that opens like a list but doesn't parse, rather than silently searching for it as text.
+
 ### Reading data from disk
 If you already have the files locally, point the CLI at them and the URLs come back as paths:
 ```bash
@@ -104,7 +106,7 @@ atom --local-path eos dataset urls 301204             # native POSIX /eos/... pa
 Run `atom --help` or `atom <group> <command> --help` for the full set of options. The deprecated library functions (`get_urls_data`, `build_mc_dataset`, `build_data_dataset`) are intentionally not exposed; use `dataset urls` and `dataset build` instead.
 
 ### Output
-Commands that return data (`dataset urls`, `dataset show`, `metadata dump`, `weights ...`) print JSON, so they pipe straight into `jq`. Commands that report state (`release show`, `release list`, `cache info`) print a short human-readable summary instead. Pass `--json` to force JSON everywhere:
+Commands that return data (`dataset urls`, `dataset show`, `metadata dump`, `weights ...`) print JSON, so they can be piped straight into `jq`. Commands that report state (`release show`, `release list`, `cache info`) print a short human-readable summary instead. Pass `--json` to force JSON everywhere:
 ```bash
 atom release show            # Release: 2024r-pp / Source: config / Cache: fresh, just now
 atom --json release show     # {"cache": "fresh, just now", "release": "2024r-pp", ...}
@@ -129,7 +131,7 @@ atom --release mysnapshot dataset list
 ```
 
 ### Update notification
-The CLI checks PyPI at most once a day for a newer release and prints a short notice to stderr if one is available; it never runs on a plain `import atlasopenmagic`. Disable it with `--no-update-check` or by setting `ATLASOPENMAGIC_NO_UPDATE_CHECK=1`.
+The CLI checks PyPI at most once a day for a newer release and prints a short notice to stderr if one is available. The check belongs to the CLI alone: using the package from Python (`import atlasopenmagic`) never triggers it, so imports in notebooks and scripts stay offline and just as fast as before. Disable it with `--no-update-check` or by setting `ATLASOPENMAGIC_NO_UPDATE_CHECK=1`.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -85,11 +85,23 @@ The command groups are:
 
 Run `atom --help` or `atom <group> <command> --help` for the full set of options. The deprecated library functions (`get_urls_data`, `build_mc_dataset`, `build_data_dataset`) are intentionally not exposed; use `dataset urls` and `dataset build` instead.
 
+### Output
+Commands that return data (`dataset urls`, `dataset show`, `metadata dump`, `weights ...`) print JSON, so they pipe straight into `jq`. Commands that report state (`release show`, `release list`, `cache info`) print a short human-readable summary instead. Pass `--json` to force JSON everywhere:
+```bash
+atom release show            # Release: 2024r-pp / Source: config / Cache: fresh, just now
+atom --json release show     # {"cache": "fresh, just now", "release": "2024r-pp", ...}
+```
+
 ### Release selection
 Each invocation is a separate process, so the release is resolved from, in order of precedence: the `--release` flag, the `ATLAS_RELEASE` environment variable, the release saved by `atom release set` (in `~/.config/atlasopenmagic/config.json`), and finally the library default. `atom release show` reports which one is in effect and where it came from.
 
 ### Caching
-Because nothing persists in memory between invocations, the CLI caches each release's metadata under `~/.cache/atlasopenmagic/` so repeated commands don't refetch the whole release. Entries expire after 7 days. Use `--refresh` to bypass the cache for one command, `atom cache info` to see what is cached, and `atom cache clear` to delete it. The cache is disposable: deleting it only costs one refetch.
+Because nothing persists in memory between invocations, the CLI caches each release's metadata under `~/.cache/atlasopenmagic/` so repeated commands don't refetch the whole release. `atom release set` downloads and caches the release up front, so the wait happens where you asked for it rather than on whichever query you happen to run first; pass `--no-fetch` to just save the setting. After that, queries are served from disk:
+```bash
+atom release set 2024r-pp    # fetches once, ~1.3s
+atom dataset list            # served from cache, ~0.1s, no network
+```
+Entries expire after 7 days. Use `--refresh` to bypass the cache for one command, `atom cache info` to see what is cached, and `atom cache clear` to delete it. The cache is disposable: deleting it only costs one refetch.
 
 `atom metadata import` loads a previously exported file into that cache under a name of your choice, which can then be selected like any other release:
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,15 +61,44 @@ all_mc = atom.get_urls('data')
 ```
 
 ## Command-line interface
-Installing the package also installs a CLI, available as both `atlasopenmagic` and the shorter `atom`. It covers the read-only lookups (metadata, URLs, weights) and prints JSON to stdout, so it composes well with tools like `jq` or with shell scripts:
-```bash
-atom --release 2024r-pp metadata 301204 --field cross_section_pb
-atom urls 301204 --skim exactly4lep --protocol https
-atom search process "pp>Zprime>ee"
-atom weights 301204
-```
-Run `atom --help` or `atom <command> --help` for the full list of commands and options. Since it wraps read-only lookups, it doesn't cover functions with local side effects or that return non-serializable Python objects (`build_dataset`, `install_from_environment`, etc.) — use the Python API for those.
+Installing the package also installs a CLI, available as both `atlasopenmagic` and the shorter `atom`. It follows a `atom <group> <command> [arguments] [options]` layout and prints JSON to stdout, so it composes well with tools like `jq` or with shell scripts.
 
+Pick a release once, then query without repeating yourself:
+```bash
+atom release set 2024r-pp
+atom dataset show 301204 --field cross_section_pb
+atom dataset urls 301204 --protocol https
+atom dataset search process "pp>Zprime>ee"
+atom weights names 301204
+```
+
+The command groups are:
+
+| Group | Commands |
+|---|---|
+| `release` | `list`, `show`, `set <name>`, `unset` |
+| `dataset` | `list`, `show <key>`, `urls <key>`, `search <field> <value>`, `build <defs.json>` |
+| `metadata` | `fields`, `keywords`, `skims`, `dump`, `export <file>`, `import <file>` |
+| `weights` | `show <key>`, `names <key>`, `list` |
+| `cache` | `info`, `clear`, `localize <path>` |
+| `env` | `install [packages...]` |
+
+Run `atom --help` or `atom <group> <command> --help` for the full set of options. The deprecated library functions (`get_urls_data`, `build_mc_dataset`, `build_data_dataset`) are intentionally not exposed; use `dataset urls` and `dataset build` instead.
+
+### Release selection
+Each invocation is a separate process, so the release is resolved from, in order of precedence: the `--release` flag, the `ATLAS_RELEASE` environment variable, the release saved by `atom release set` (in `~/.config/atlasopenmagic/config.json`), and finally the library default. `atom release show` reports which one is in effect and where it came from.
+
+### Caching
+Because nothing persists in memory between invocations, the CLI caches each release's metadata under `~/.cache/atlasopenmagic/` so repeated commands don't refetch the whole release. Entries expire after 7 days. Use `--refresh` to bypass the cache for one command, `atom cache info` to see what is cached, and `atom cache clear` to delete it. The cache is disposable: deleting it only costs one refetch.
+
+`atom metadata import` loads a previously exported file into that cache under a name of your choice, which can then be selected like any other release:
+```bash
+atom metadata export snapshot.json
+atom metadata import snapshot.json --as-release mysnapshot
+atom --release mysnapshot dataset list
+```
+
+### Update notification
 The CLI checks PyPI at most once a day for a newer release and prints a short notice to stderr if one is available; it never runs on a plain `import atlasopenmagic`. Disable it with `--no-update-check` or by setting `ATLASOPENMAGIC_NO_UPDATE_CHECK=1`.
 
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ The command groups are:
 | `cache` | `info`, `clear`, `localize <path>` |
 | `env` | `install [packages...]` |
 
+### Searching
+`dataset search` reads its value as JSON where it can, so searches keep the types the Python API expects:
+```bash
+atom dataset search nEvents 20000                     # number, not the string "20000"
+atom dataset search keywords '["2electron","BSM"]'    # requires both keywords
+atom dataset search Filters null                      # datasets where the field is empty
+atom dataset search process "pp>Zprime>ee"            # not valid JSON, so plain text
+atom dataset search keywords 2024 --raw               # force text for a numeric-looking value
+```
+
+### Reading data from disk
+If you already have the files locally, point the CLI at them and the URLs come back as paths:
+```bash
+atom release set 2024r-pp --local-path /data/atlas    # remembered for this release
+atom --local-path eos dataset urls 301204             # native POSIX /eos/... paths
+```
+`--local-path` on its own applies to a single command; on `release set` it is saved alongside the release. Use `atom cache localize <path>` instead when you want only the files that actually exist locally rewritten, leaving the rest as remote URLs.
+
 Run `atom --help` or `atom <group> <command> --help` for the full set of options. The deprecated library functions (`get_urls_data`, `build_mc_dataset`, `build_data_dataset`) are intentionally not exposed; use `dataset urls` and `dataset build` instead.
 
 ### Output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlasopenmagic"
-version = "1.9.1"
+version = "1.10.0"
 description = "A utility package for retrieving ATLAS open data URLs and metadata."
 authors = [
     { name="ATLAS Collaboration", email="atlas-outreach-opendata-support@cern.ch" }
@@ -45,6 +45,10 @@ dependencies = [
     "pyyaml",
     "tqdm"
 ]
+
+[project.scripts]
+atlasopenmagic = "atlasopenmagic.cli:main"
+atom = "atlasopenmagic.cli:main"
 
 [project.urls]
 Homepage = "https://opendata.atlas.cern/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 
     "Operating System :: OS Independent",
 

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -1,15 +1,28 @@
 """Command-line interface for atlasopenmagic.
 
-Installed as both `atlasopenmagic` and `atom`. Wraps the read/query
-functions of the Python API (datasets, metadata, URLs, weights) so they
-can be used from shell scripts and other non-Python tooling. Output is
-JSON on stdout so it composes with tools like `jq`; informational
-messages (including the update notice) go to stderr.
+Installed as both `atlasopenmagic` and `atom`. Exposes the package's public
+API as `atom <group> <command> [arguments] [options]`, so ATLAS Open Data can
+be queried from shell scripts and other non-Python tooling. Output is JSON on
+stdout so it composes with tools like `jq`; informational messages (including
+the update notice) go to stderr.
+
+Unlike a Python session, each CLI invocation is a fresh process, so the
+library's in-memory release selection and metadata cache do not survive
+between commands. Two pieces of on-disk state make up for that:
+
+* a config file holding the release chosen with `atom release set`, and
+* a per-release metadata cache, so repeated commands don't refetch the
+  whole release from the API every time.
+
+Deprecated library functions (`get_urls_data`, `build_mc_dataset`,
+`build_data_dataset`) are deliberately not exposed here; their replacements
+are `dataset urls` and `dataset build`.
 """
 
 import argparse
 import json
 import os
+import re
 import sys
 import threading
 import time
@@ -18,16 +31,34 @@ from importlib.metadata import PackageNotFoundError, version
 import requests
 
 from . import metadata as _metadata
+from . import utils as _utils
 from . import weights as _weights
 
 _PACKAGE_NAME = "atlasopenmagic"
 _PYPI_URL = f"https://pypi.org/pypi/{_PACKAGE_NAME}/json"
-_CACHE_PATH = os.path.join(
+
+# Disposable state: safe to delete at any time, rebuilt from the API on demand.
+_CACHE_DIR = os.path.join(
     os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")),
     "atlasopenmagic",
-    "update_check.json",
 )
+_CACHE_PATH = os.path.join(_CACHE_DIR, "update_check.json")
+
+# Durable state: records what the user explicitly asked for.
+_CONFIG_PATH = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+    "atlasopenmagic",
+    "config.json",
+)
+
 _CHECK_INTERVAL_SECONDS = 24 * 3600
+
+# Published releases are effectively immutable, so this can be generous; it
+# exists to eventually pick up datasets or skims added to an existing release.
+_METADATA_CACHE_TTL_SECONDS = 7 * 24 * 3600
+
+# Release names become filenames, so keep them to something obviously safe.
+_SAFE_RELEASE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 # --- Update notification (CLI only; never runs on `import atlasopenmagic`) ---
@@ -119,6 +150,120 @@ def _print_update_notice(check):
         print(f"\n{result['notice']}", file=sys.stderr)
 
 
+# --- Persistent configuration ---
+
+
+def _read_config() -> dict:
+    """Read the CLI config file, treating any unreadable or malformed file as empty."""
+    try:
+        with open(_CONFIG_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_config(data: dict) -> None:
+    """Write the CLI config file.
+
+    Unlike the metadata cache, failures here are not swallowed: the user asked
+    for this to be remembered, so they need to know when it wasn't.
+    """
+    os.makedirs(os.path.dirname(_CONFIG_PATH), exist_ok=True)
+    with open(_CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+# --- Release selection ---
+
+
+def _metadata_cache_path(release: str) -> str:
+    if not _SAFE_RELEASE_RE.match(release):
+        raise ValueError(f"Invalid release name: '{release}'.")
+    return os.path.join(_CACHE_DIR, f"metadata-{release}.json")
+
+
+def _known_releases() -> list[str]:
+    """Releases that may be selected: the published ones plus any imported locally."""
+    known = list(_metadata.RELEASES_DESC)
+    try:
+        cached = os.listdir(_CACHE_DIR)
+    except OSError:
+        cached = []
+    for name in cached:
+        if name.startswith("metadata-") and name.endswith(".json"):
+            release = name[len("metadata-") : -len(".json")]
+            if release not in known:
+                known.append(release)
+    return known
+
+
+def _validate_release(release: str) -> None:
+    """Raise ValueError if `release` is neither published nor present in the local cache."""
+    if release not in _known_releases():
+        raise ValueError(f"Invalid release '{release}'. Use one of: {', '.join(_known_releases())}")
+
+
+def _resolve_release(cli_release):
+    """Resolve the release to use, returning (release, source).
+
+    Precedence follows the usual CLI convention: an explicit flag beats the
+    environment, which beats saved config, which beats the library default.
+    """
+    if cli_release:
+        return cli_release, "--release"
+    env_release = os.environ.get("ATLAS_RELEASE")
+    if env_release:
+        return env_release, "ATLAS_RELEASE"
+    configured = _read_config().get("release")
+    if configured:
+        return configured, "config"
+    return _metadata.get_current_release(), "default"
+
+
+# --- Metadata cache ---
+
+
+def _cache_age(path: str):
+    """Age of `path` in seconds, or None if it doesn't exist."""
+    try:
+        return time.time() - os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def _save_metadata_cache(cache_file: str) -> None:
+    try:
+        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+        _metadata.save_metadata(cache_file)
+    except OSError:
+        pass  # Same as the update cache: never fail a command over a cache write.
+
+
+def _apply_release(release: str, refresh: bool, needs_full: bool) -> None:
+    """Point the library at `release`, loading metadata from cache where possible."""
+    _validate_release(release)
+    cache_file = _metadata_cache_path(release)
+
+    age = None if refresh else _cache_age(cache_file)
+    if age is not None and age < _METADATA_CACHE_TTL_SECONDS:
+        try:
+            _metadata.read_metadata(cache_file, release=release)
+            return
+        except (OSError, ValueError):
+            pass  # Corrupt or truncated cache: fall through and refetch.
+
+    if not needs_full:
+        # Single-dataset lookups hit the per-dataset API endpoint, which is far
+        # cheaper than pulling a whole release just to read one field. Set the
+        # release directly rather than via set_release(), which always fetches.
+        _metadata.current_release = release
+        return
+
+    _metadata.set_release(release)
+    _save_metadata_cache(cache_file)
+
+
 # --- Output helpers ---
 
 
@@ -126,61 +271,302 @@ def _emit(data):
     print(json.dumps(data, indent=2, sort_keys=True, default=str))
 
 
-# --- Command implementations ---
+def _read_json_file(path: str):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
 
 
-def _cmd_releases(_args):
+# --- release ---
+
+
+def _cmd_release_list(_args):
     _emit(_metadata.RELEASES_DESC)
 
 
-def _cmd_current_release(_args):
-    _emit(_metadata.get_current_release())
+def _cmd_release_show(args):
+    release, source = _resolve_release(args.release)
+    _emit({"release": release, "source": source})
 
 
-def _cmd_datasets(_args):
+def _cmd_release_set(args):
+    _validate_release(args.name)
+    config = _read_config()
+    config["release"] = args.name
+    _write_config(config)
+    _emit({"release": args.name, "config_file": _CONFIG_PATH})
+
+
+def _cmd_release_unset(_args):
+    config = _read_config()
+    config.pop("release", None)
+    _write_config(config)
+    _emit({"release": None, "config_file": _CONFIG_PATH})
+
+
+# --- dataset ---
+
+
+def _cmd_dataset_list(_args):
     _emit(_metadata.available_datasets())
 
 
-def _cmd_skims(_args):
-    _emit(_metadata.available_skims())
-
-
-def _cmd_keywords(_args):
-    _emit(_metadata.available_keywords())
-
-
-def _cmd_fields(_args):
-    _emit(_metadata.get_metadata_fields())
-
-
-def _cmd_metadata(args):
+def _cmd_dataset_show(args):
     if args.full:
         _emit(_metadata.get_all_info(args.key, args.field))
     else:
         _emit(_metadata.get_metadata(args.key, args.field))
 
 
-def _cmd_urls(args):
+def _cmd_dataset_urls(args):
     _emit(_metadata.get_urls(args.key, skim=args.skim, protocol=args.protocol, cache=args.cache))
 
 
-def _cmd_search(args):
+def _cmd_dataset_search(args):
     _emit(_metadata.match_metadata(args.field, args.value, float_tolerance=args.tolerance))
 
 
-def _cmd_weights(args):
+def _cmd_dataset_build(args):
+    samples_defs = _read_json_file(args.definitions)
+    if not isinstance(samples_defs, dict):
+        raise ValueError(f"{args.definitions} must contain a JSON object mapping sample names to definitions.")
+    _emit(
+        _utils.build_dataset(
+            samples_defs,
+            skim=args.skim,
+            protocol=args.protocol,
+            cache=args.cache,
+        )
+    )
+
+
+# --- metadata ---
+
+
+def _cmd_metadata_fields(_args):
+    _emit(_metadata.get_metadata_fields())
+
+
+def _cmd_metadata_keywords(_args):
+    _emit(_metadata.available_keywords())
+
+
+def _cmd_metadata_skims(_args):
+    _emit(_metadata.available_skims())
+
+
+def _cmd_metadata_dump(_args):
+    _emit(_metadata.get_all_metadata())
+
+
+def _cmd_metadata_export(args):
+    _metadata.save_metadata(args.file)
+    _emit({"exported": args.file, "release": _metadata.get_current_release()})
+
+
+def _cmd_metadata_import(args):
+    _metadata.read_metadata(args.file, release=args.as_release)
+    # Persist into the cache so subsequent commands can select this release.
+    _save_metadata_cache(_metadata_cache_path(args.as_release))
+    _emit({"imported": args.file, "release": args.as_release})
+
+
+# --- weights ---
+
+
+def _cmd_weights_show(args):
     _emit(_weights.get_weights(args.key, e_tag=args.e_tag))
 
 
-def _cmd_weight_names(args):
+def _cmd_weights_names(args):
     _emit(_weights.get_weight_names(args.key, e_tag=args.e_tag))
 
 
-def _cmd_all_weights(args):
+def _cmd_weights_list(args):
     _emit(_weights.get_all_weights_for_release(release_name=args.for_release))
 
 
+# --- cache ---
+
+
+def _cmd_cache_info(_args):
+    entries = []
+    for release in sorted(_known_releases()):
+        path = _metadata_cache_path(release)
+        age = _cache_age(path)
+        if age is None:
+            continue
+        entries.append(
+            {
+                "release": release,
+                "path": path,
+                "age_seconds": int(age),
+                "stale": age >= _METADATA_CACHE_TTL_SECONDS,
+            }
+        )
+    _emit({"cache_dir": _CACHE_DIR, "entries": entries})
+
+
+def _cmd_cache_clear(_args):
+    removed = []
+    # Only ever remove files we know we wrote, never a blind glob of the directory.
+    for release in sorted(_known_releases()):
+        path = _metadata_cache_path(release)
+        try:
+            os.remove(path)
+        except OSError:
+            continue
+        removed.append(path)
+    _emit({"removed": removed})
+
+
+def _cmd_cache_localize(args):
+    _metadata.find_all_files(args.path, warnmissing=args.warn_missing)
+    release = _metadata.get_current_release()
+    _save_metadata_cache(_metadata_cache_path(release))
+    _emit({"localized": args.path, "release": release})
+
+
+# --- env ---
+
+
+def _cmd_env_install(args):
+    _utils.install_from_environment(*args.packages, environment_file=args.environment_file)
+    _emit({"installed": list(args.packages) or "all", "environment_file": args.environment_file})
+
+
 # --- Argument parsing ---
+
+
+def _add_release_commands(sub):
+    """`release` manages which release other commands act on. Local config only."""
+    parser = sub.add_parser("release", help="Inspect or set the release used by default")
+    parser.set_defaults(loads_metadata=False)
+    group = parser.add_subparsers(dest="release_command", required=True)
+
+    group.add_parser("list", help="List available data releases").set_defaults(func=_cmd_release_list)
+    group.add_parser("show", help="Show the release in effect and where it came from").set_defaults(
+        func=_cmd_release_show
+    )
+    p = group.add_parser("set", help="Save a release to use for future commands")
+    p.add_argument("name", help="Release name, e.g. 2024r-pp")
+    p.set_defaults(func=_cmd_release_set)
+    group.add_parser("unset", help="Forget the saved release").set_defaults(func=_cmd_release_unset)
+
+
+def _add_dataset_commands(sub):
+    """`dataset` covers discovery and per-dataset lookups."""
+    parser = sub.add_parser("dataset", help="Find datasets and get their metadata or file URLs")
+    group = parser.add_subparsers(dest="dataset_command", required=True)
+
+    group.add_parser("list", help="List dataset IDs in the active release").set_defaults(
+        func=_cmd_dataset_list, needs_full=True
+    )
+
+    p = group.add_parser("show", help="Show metadata for one dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--field", help="Return only this metadata field")
+    p.add_argument("--full", action="store_true", help="Include file_list and skims")
+    p.set_defaults(func=_cmd_dataset_show)
+
+    p = group.add_parser("urls", help="Get file URLs for one dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--skim", default="noskim", help="Skim type (default: noskim)")
+    p.add_argument("--protocol", choices=["root", "https", "eos"], default="root")
+    cache_group = p.add_mutually_exclusive_group()
+    cache_group.add_argument("--cache", dest="cache", action="store_true", default=None)
+    cache_group.add_argument("--no-cache", dest="cache", action="store_false")
+    p.set_defaults(func=_cmd_dataset_urls)
+
+    p = group.add_parser("search", help="Find datasets whose metadata field matches a value")
+    p.add_argument("field", help="Metadata field to search, e.g. process")
+    p.add_argument("value", help="Value to match")
+    p.add_argument("--tolerance", type=float, default=0.01, help="Fractional tolerance for float fields")
+    p.set_defaults(func=_cmd_dataset_search, needs_full=True)
+
+    p = group.add_parser("build", help="Build a sample->URLs mapping from a JSON definitions file")
+    p.add_argument("definitions", help="JSON file mapping sample names to {'dids': [...], 'color': ...}")
+    p.add_argument("--skim", default="noskim", help="Skim type (default: noskim)")
+    p.add_argument("--protocol", choices=["root", "https", "eos"], default="https")
+    cache_group = p.add_mutually_exclusive_group()
+    cache_group.add_argument("--cache", dest="cache", action="store_true", default=False)
+    cache_group.add_argument("--no-cache", dest="cache", action="store_false")
+    p.set_defaults(func=_cmd_dataset_build)
+
+
+def _add_metadata_commands(sub):
+    """`metadata` covers release-wide vocabularies and bulk import/export."""
+    parser = sub.add_parser("metadata", help="Release-wide metadata vocabularies and bulk transfer")
+    group = parser.add_subparsers(dest="metadata_command", required=True)
+
+    group.add_parser("fields", help="List available metadata fields").set_defaults(
+        func=_cmd_metadata_fields, needs_full=True
+    )
+    group.add_parser("keywords", help="List keywords used in the active release").set_defaults(
+        func=_cmd_metadata_keywords, needs_full=True
+    )
+    group.add_parser("skims", help="List skims available in the active release").set_defaults(
+        func=_cmd_metadata_skims, needs_full=True
+    )
+    group.add_parser("dump", help="Print the whole metadata dictionary").set_defaults(
+        func=_cmd_metadata_dump, needs_full=True
+    )
+
+    p = group.add_parser("export", help="Write the active release's metadata to a .json or .txt file")
+    p.add_argument("file", help="Destination file; extension selects the format")
+    p.set_defaults(func=_cmd_metadata_export, needs_full=True)
+
+    p = group.add_parser("import", help="Load metadata from a file into the local cache")
+    p.add_argument("file", help="JSON file previously written by `metadata export`")
+    p.add_argument("--as-release", dest="as_release", default="custom", help="Name to store it under")
+    p.set_defaults(func=_cmd_metadata_import, loads_metadata=False)
+
+
+def _add_weights_commands(sub):
+    """`weights` covers Monte Carlo weight metadata."""
+    parser = sub.add_parser("weights", help="Query Monte Carlo weight metadata")
+    group = parser.add_subparsers(dest="weights_command", required=True)
+
+    p = group.add_parser("show", help="Show weight metadata for one dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--e-tag", dest="e_tag")
+    p.set_defaults(func=_cmd_weights_show)
+
+    p = group.add_parser("names", help="List weight names for one dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--e-tag", dest="e_tag")
+    p.set_defaults(func=_cmd_weights_names)
+
+    p = group.add_parser("list", help="List weight names for every dataset in a release")
+    p.add_argument("--for-release", dest="for_release", help="Defaults to the active release")
+    p.set_defaults(func=_cmd_weights_list)
+
+
+def _add_cache_commands(sub):
+    """`cache` manages the on-disk metadata cache."""
+    parser = sub.add_parser("cache", help="Inspect, clear, or localize the metadata cache")
+    parser.set_defaults(loads_metadata=False)
+    group = parser.add_subparsers(dest="cache_command", required=True)
+
+    group.add_parser("info", help="Show which releases are cached locally").set_defaults(func=_cmd_cache_info)
+    group.add_parser("clear", help="Delete all cached release metadata").set_defaults(func=_cmd_cache_clear)
+
+    p = group.add_parser("localize", help="Rewrite cached URLs to point at a local copy of the files")
+    p.add_argument("path", help="Root directory holding your local copy of the data")
+    p.add_argument("--warn-missing", action="store_true", help="Warn about files not found locally")
+    # Needs the release loaded so the rewritten metadata can be saved back.
+    p.set_defaults(func=_cmd_cache_localize, loads_metadata=True, needs_full=True)
+
+
+def _add_env_commands(sub):
+    """`env` covers environment setup helpers."""
+    parser = sub.add_parser("env", help="Environment setup helpers")
+    parser.set_defaults(loads_metadata=False)
+    group = parser.add_subparsers(dest="env_command", required=True)
+
+    p = group.add_parser("install", help="Install packages pinned in an environment.yml")
+    p.add_argument("packages", nargs="*", help="Packages to install; omit to install all")
+    p.add_argument("--environment-file", dest="environment_file", help="Path or URL to environment.yml")
+    p.set_defaults(func=_cmd_env_install)
 
 
 def _build_parser():
@@ -193,11 +579,16 @@ def _build_parser():
         action="version",
         version=f"%(prog)s {_installed_version() or 'unknown'}",
     )
-    parser.add_argument("--release", help="Data release to use for this command (e.g. 2024r-pp)")
+    parser.add_argument("--release", help="Release to use for this command, overriding any saved setting")
     parser.add_argument(
         "--verbosity",
         choices=["error", "warning", "info", "debug"],
         help="Log verbosity for the underlying API calls",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Ignore cached metadata and refetch from the API",
     )
     parser.add_argument(
         "--no-update-check",
@@ -205,55 +596,19 @@ def _build_parser():
         help="Skip the PyPI check for a newer atlasopenmagic release",
     )
 
+    # Most commands only read one dataset; those needing the whole release
+    # loaded opt in with needs_full=True, and purely local ones with
+    # loads_metadata=False.
+    parser.set_defaults(loads_metadata=True, needs_full=False)
+
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("releases", help="List available data releases").set_defaults(func=_cmd_releases)
-    sub.add_parser("current-release", help="Show the active data release").set_defaults(
-        func=_cmd_current_release
-    )
-    sub.add_parser("datasets", help="List dataset IDs for the active release").set_defaults(func=_cmd_datasets)
-    sub.add_parser("skims", help="List available skims for the active release").set_defaults(func=_cmd_skims)
-    sub.add_parser("keywords", help="List available keywords for the active release").set_defaults(
-        func=_cmd_keywords
-    )
-    sub.add_parser("fields", help="List available metadata fields for the active release").set_defaults(
-        func=_cmd_fields
-    )
-
-    p = sub.add_parser("metadata", help="Show metadata for a dataset")
-    p.add_argument("key", help="Dataset number or physics_short name")
-    p.add_argument("--field", help="Return only this metadata field")
-    p.add_argument("--full", action="store_true", help="Include file_list and skims")
-    p.set_defaults(func=_cmd_metadata)
-
-    p = sub.add_parser("urls", help="Get file URLs for a dataset")
-    p.add_argument("key", help="Dataset number or physics_short name")
-    p.add_argument("--skim", default="noskim", help="Skim type (default: noskim)")
-    p.add_argument("--protocol", choices=["root", "https", "eos"], default="root")
-    cache_group = p.add_mutually_exclusive_group()
-    cache_group.add_argument("--cache", dest="cache", action="store_true", default=None)
-    cache_group.add_argument("--no-cache", dest="cache", action="store_false")
-    p.set_defaults(func=_cmd_urls)
-
-    p = sub.add_parser("search", help="Find datasets by metadata field/value")
-    p.add_argument("field", help="Metadata field to search, e.g. process")
-    p.add_argument("value", help="Value to match")
-    p.add_argument("--tolerance", type=float, default=0.01, help="Fractional tolerance for float fields")
-    p.set_defaults(func=_cmd_search)
-
-    p = sub.add_parser("weights", help="Get MC weight metadata for a dataset")
-    p.add_argument("key", help="Dataset number or physics_short name")
-    p.add_argument("--e-tag", dest="e_tag")
-    p.set_defaults(func=_cmd_weights)
-
-    p = sub.add_parser("weight-names", help="List MC weight names for a dataset")
-    p.add_argument("key", help="Dataset number or physics_short name")
-    p.add_argument("--e-tag", dest="e_tag")
-    p.set_defaults(func=_cmd_weight_names)
-
-    p = sub.add_parser("all-weights", help="List weight names for every dataset in a release")
-    p.add_argument("--for-release", dest="for_release", help="Defaults to the active release")
-    p.set_defaults(func=_cmd_all_weights)
+    _add_release_commands(sub)
+    _add_dataset_commands(sub)
+    _add_metadata_commands(sub)
+    _add_weights_commands(sub)
+    _add_cache_commands(sub)
+    _add_env_commands(sub)
 
     return parser
 
@@ -265,18 +620,24 @@ def main(argv=None) -> int:
 
     update_check = _start_update_check(args.no_update_check)
 
-    if args.verbosity:
-        _metadata.set_verbosity(args.verbosity)
-    if args.release:
-        _metadata.set_release(args.release)
+    # Quiet by default, the way a CLI is expected to behave: the library
+    # defaults to INFO, which narrates every cache load on stderr.
+    _metadata.set_verbosity(args.verbosity or "warning")
 
     try:
+        if args.loads_metadata:
+            release, _ = _resolve_release(args.release)
+            _apply_release(release, args.refresh, args.needs_full)
         args.func(args)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
+    # RequestException subclasses OSError, so it has to be caught first.
     except requests.exceptions.RequestException as e:
         print(f"Network error: {e}", file=sys.stderr)
+        return 1
+    except OSError as e:
+        print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:
         _print_update_notice(update_check)

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -13,6 +13,10 @@ file holding the release chosen with `atom release set`, and a per-release
 metadata cache, so repeated commands don't refetch the whole release from
 the API every time.
 
+The module is laid out in the order a command flows through it: update check,
+config, release resolution, metadata cache, output helpers, one `_cmd_*`
+handler per command, then the parser builders that wire them together.
+
 Deprecated library functions (`get_urls_data`, `build_mc_dataset`,
 `build_data_dataset`) are deliberately not exposed here; their replacements
 are `dataset urls` and `dataset build`.
@@ -26,6 +30,7 @@ import sys
 import threading
 import time
 from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Optional
 
 import requests
 
@@ -34,6 +39,16 @@ import requests
 from atlasopenmagic import metadata as _metadata
 from atlasopenmagic import utils as _utils
 from atlasopenmagic import weights as _weights
+
+# argparse's subparser action has no public name, so alias the private one once
+# here rather than repeating it in every parser builder's annotation. A `sub`
+# argument below is always the object returned by `parser.add_subparsers()`, on
+# which `.add_parser(...)` creates one command.
+_SubParsers = argparse._SubParsersAction  # pylint: disable=protected-access
+
+# The background update check hands back the thread it started plus the dict
+# that thread writes its result into.
+_UpdateCheck = Optional[tuple[threading.Thread, dict]]
 
 _PACKAGE_NAME = "atlasopenmagic"
 _PYPI_URL = f"https://pypi.org/pypi/{_PACKAGE_NAME}/json"
@@ -61,6 +76,10 @@ _METADATA_CACHE_TTL_SECONDS = 7 * 24 * 3600
 # Release names become filenames, so keep them to something obviously safe.
 _SAFE_RELEASE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
+# A search value that opens with a bracket was almost certainly meant to be a
+# JSON list or object; see _coerce_search_value for why that matters.
+_LOOKS_STRUCTURED_RE = re.compile(r"^\s*[\[{]")
+
 # Sentinel local path meaning "native POSIX EOS access", as set_release() accepts.
 _LOCAL_PATH_EOS = "eos"
 
@@ -68,20 +87,26 @@ _LOCAL_PATH_EOS = "eos"
 _DEFAULT_PAGE_SIZE = 1000
 
 
-# --- Update notification (CLI only; never runs on `import atlasopenmagic`) ---
+# --- Update notification ---
+#
+# This runs only from the CLI. Importing atlasopenmagic in a script or notebook
+# never reaches this module, so no import is ever slowed down or made to touch
+# the network by it.
 
 
-def _installed_version():
+def _installed_version() -> Optional[str]:
+    """Version of the installed package, or None if it isn't installed (e.g. run from a source tree)."""
     try:
         return version(_PACKAGE_NAME)
     except PackageNotFoundError:
         return None
 
 
-def _version_tuple(v):
+def _version_tuple(v: str) -> tuple[int, ...]:
     """Loose numeric-prefix comparison, good enough for this package's plain X.Y.Z versions."""
     parts = []
     for chunk in v.split("."):
+        # Stop at the first non-digit so a suffix like "1rc2" still compares as 1.
         digits = ""
         for ch in chunk:
             if not ch.isdigit():
@@ -91,7 +116,8 @@ def _version_tuple(v):
     return tuple(parts)
 
 
-def _read_cache():
+def _read_cache() -> dict:
+    """Read the update-check cache, treating an unreadable or malformed file as empty."""
     try:
         with open(_CACHE_PATH, encoding="utf-8") as f:
             return json.load(f)
@@ -99,7 +125,8 @@ def _read_cache():
         return {}
 
 
-def _write_cache(data):
+def _write_cache(data: dict) -> None:
+    """Record when PyPI was last checked, so the next run can skip the network."""
     try:
         os.makedirs(os.path.dirname(_CACHE_PATH), exist_ok=True)
         with open(_CACHE_PATH, "w", encoding="utf-8") as f:
@@ -108,7 +135,12 @@ def _write_cache(data):
         pass  # Caching is a nice-to-have; never fail the command over it.
 
 
-def _fetch_latest_version():
+def _fetch_latest_version() -> Optional[str]:
+    """Ask PyPI for the newest published version, or None if that doesn't work out.
+
+    Every failure is deliberately equivalent to "don't know": this is a courtesy
+    notice, so being offline or behind a proxy must not disturb the real command.
+    """
     try:
         resp = requests.get(_PYPI_URL, timeout=2)
         resp.raise_for_status()
@@ -117,12 +149,13 @@ def _fetch_latest_version():
         return None
 
 
-def _check_for_update(result: dict):
+def _check_for_update(result: dict) -> None:
     """Populate result['notice'] if a newer release is available. Runs in a background thread."""
     installed = _installed_version()
     if not installed:
         return
 
+    # At most one PyPI request a day; in between, reuse the cached answer.
     cache = _read_cache()
     now = time.time()
     if now - cache.get("checked_at", 0) < _CHECK_INTERVAL_SECONDS:
@@ -139,8 +172,12 @@ def _check_for_update(result: dict):
         )
 
 
-def _start_update_check(disabled: bool):
-    result = {}
+def _start_update_check(disabled: bool) -> _UpdateCheck:
+    """Start the update check in the background, or return None if it is switched off.
+
+    It runs concurrently with the actual command so the user never waits on it.
+    """
+    result: dict = {}
     if disabled or os.environ.get("ATLASOPENMAGIC_NO_UPDATE_CHECK"):
         return None
     thread = threading.Thread(target=_check_for_update, args=(result,), daemon=True)
@@ -148,7 +185,12 @@ def _start_update_check(disabled: bool):
     return thread, result
 
 
-def _print_update_notice(check):
+def _print_update_notice(check: _UpdateCheck) -> None:
+    """Print the notice if the check found one, waiting only briefly for it.
+
+    The thread is a daemon and the timeout is short, so a hung network request
+    delays exit by at most a couple of seconds and never blocks it.
+    """
     if check is None:
         return
     thread, result = check
@@ -185,6 +227,7 @@ def _write_config(data: dict) -> None:
 
 
 def _metadata_cache_path(release: str) -> str:
+    """Cache file for `release`, rejecting names that wouldn't be safe as a filename."""
     if not _SAFE_RELEASE_RE.match(release):
         raise ValueError(f"Invalid release name: '{release}'.")
     return os.path.join(_CACHE_DIR, f"metadata-{release}.json")
@@ -197,6 +240,8 @@ def _known_releases() -> list[str]:
         cached = os.listdir(_CACHE_DIR)
     except OSError:
         cached = []
+    # A cache file is the only trace an imported release leaves, so the filenames
+    # are what make `metadata import --as-release foo` selectable afterwards.
     for name in cached:
         if name.startswith("metadata-") and name.endswith(".json"):
             release = name[len("metadata-") : -len(".json")]
@@ -211,11 +256,12 @@ def _validate_release(release: str) -> None:
         raise ValueError(f"Invalid release '{release}'. Use one of: {', '.join(_known_releases())}")
 
 
-def _resolve_release(cli_release):
+def _resolve_release(cli_release: Optional[str]) -> tuple[str, str]:
     """Resolve the release to use, returning (release, source).
 
     Precedence follows the usual CLI convention: an explicit flag beats the
     environment, which beats saved config, which beats the library default.
+    The source is reported by `release show` so the choice is never a mystery.
     """
     if cli_release:
         return cli_release, "--release"
@@ -231,7 +277,7 @@ def _resolve_release(cli_release):
 # --- Metadata cache ---
 
 
-def _cache_age(path: str):
+def _cache_age(path: str) -> Optional[float]:
     """Age of `path` in seconds, or None if it doesn't exist."""
     try:
         return time.time() - os.path.getmtime(path)
@@ -240,6 +286,7 @@ def _cache_age(path: str):
 
 
 def _save_metadata_cache(cache_file: str) -> None:
+    """Write the library's currently loaded metadata to `cache_file`."""
     try:
         os.makedirs(os.path.dirname(cache_file), exist_ok=True)
         _metadata.save_metadata(cache_file)
@@ -247,15 +294,17 @@ def _save_metadata_cache(cache_file: str) -> None:
         pass  # Same as the update cache: never fail a command over a cache write.
 
 
-def _resolve_local_path(release: str, cli_local_path):
+def _resolve_local_path(release: str, cli_local_path: Optional[str]) -> Optional[str]:
     """Resolve the local data path for `release`: flag first, then saved config."""
     if cli_local_path is not None:
         return cli_local_path or None  # An empty --local-path clears it for this run.
     return _read_config().get("local_paths", {}).get(release)
 
 
-def _apply_local_path(local_path) -> None:
+def _apply_local_path(local_path: Optional[str]) -> None:
     """Point the library at a local copy of the data, as set_release(local_path=...) does."""
+    # Warn rather than fail: the path may be valid on the machine that will
+    # eventually consume the URLs, which isn't necessarily this one.
     if local_path and local_path != _LOCAL_PATH_EOS and not os.path.isdir(local_path):
         print(
             f"Warning: local path '{local_path}' does not exist; URLs will point at it anyway.",
@@ -264,7 +313,7 @@ def _apply_local_path(local_path) -> None:
     _metadata.current_local_path = local_path
 
 
-def _load_metadata_for(release: str, refresh: bool, needs_full: bool, page_size) -> None:
+def _load_metadata_for(release: str, refresh: bool, needs_full: bool, page_size: Optional[int]) -> None:
     """Populate the library's metadata cache for `release`, from disk where possible."""
     cache_file = _metadata_cache_path(release)
 
@@ -287,7 +336,13 @@ def _load_metadata_for(release: str, refresh: bool, needs_full: bool, page_size)
     _save_metadata_cache(cache_file)
 
 
-def _apply_release(release: str, refresh: bool, needs_full: bool, local_path=None, page_size=None) -> None:
+def _apply_release(
+    release: str,
+    refresh: bool,
+    needs_full: bool,
+    local_path: Optional[str] = None,
+    page_size: Optional[int] = None,
+) -> None:
     """Point the library at `release`, loading metadata from cache where possible."""
     _validate_release(release)
     _load_metadata_for(release, refresh, needs_full, page_size)
@@ -298,16 +353,23 @@ def _apply_release(release: str, refresh: bool, needs_full: bool, local_path=Non
 # --- Output helpers ---
 
 
-def _emit(data):
+def _emit(data: Any) -> None:
+    """Print a result as JSON on stdout.
+
+    Sorted keys keep output stable enough to diff between runs; `default=str`
+    is a backstop so an unexpected non-serialisable value degrades to its
+    string form instead of crashing the command.
+    """
     print(json.dumps(data, indent=2, sort_keys=True, default=str))
 
 
-def _read_json_file(path: str):
+def _read_json_file(path: str) -> Any:
+    """Load a JSON file, letting OSError and ValueError reach main()'s handlers."""
     with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
-def _coerce_search_value(value: str, raw: bool):
+def _coerce_search_value(value: str, raw: bool) -> Any:
     """Turn a command-line search value into the type match_metadata expects.
 
     A shell can only hand over strings, but match_metadata compares some fields
@@ -321,10 +383,21 @@ def _coerce_search_value(value: str, raw: bool):
     try:
         return json.loads(value)
     except ValueError:
+        # Falling back to text is right for values like `pp>Zprime>ee`, but a
+        # value that opens like a JSON list usually means the shell stripped the
+        # quotes: bash turns an unquoted ["a","b"] into [a,b], which would then
+        # be searched for as literal text and quietly match nothing.
+        if _LOOKS_STRUCTURED_RE.match(value):
+            print(
+                f"Warning: '{value}' is not valid JSON, so it is being searched for as text. "
+                "If you meant a list, quote it so the shell keeps it intact: "
+                '\'["2electron","BSM"]\'. Pass --raw to silence this.',
+                file=sys.stderr,
+            )
         return value
 
 
-def _validate_samples_defs(samples_defs, path: str) -> None:
+def _validate_samples_defs(samples_defs: Any, path: str) -> None:
     """Check a `dataset build` definitions file before handing it to the library.
 
     build_dataset() iterates `info["dids"]` directly, so a missing key raises a
@@ -366,6 +439,14 @@ def _describe_cache(release: str) -> str:
     return f"{state}, {_format_age(age)}"
 
 
+# --- Command handlers ---
+#
+# Every _cmd_* function takes the parsed argparse.Namespace and returns None:
+# they print and are the last thing a command does, so there is nothing to hand
+# back. The early `return`s below are just bail-outs after emitting JSON.
+# Handlers named `_args` ignore their argument entirely.
+
+
 # --- release ---
 
 
@@ -378,7 +459,8 @@ def _release_catalogue() -> dict[str, str]:
     return catalogue
 
 
-def _cmd_release_list(args):
+def _cmd_release_list(args: argparse.Namespace) -> None:
+    """List every selectable release, marking the active one with `*`."""
     catalogue = _release_catalogue()
     if args.json:
         _emit(catalogue)
@@ -390,7 +472,8 @@ def _cmd_release_list(args):
         print(f"{marker} {name.ljust(width)}  {description}")
 
 
-def _cmd_release_show(args):
+def _cmd_release_show(args: argparse.Namespace) -> None:
+    """Report the release in effect, where it came from, and its cache state."""
     release, source = _resolve_release(args.release)
     local_path = _resolve_local_path(release, args.local_path)
     if args.json:
@@ -409,7 +492,8 @@ def _cmd_release_show(args):
     print(f"Data:    {local_path or 'remote'}")
 
 
-def _cmd_release_set(args):
+def _cmd_release_set(args: argparse.Namespace) -> None:
+    """Save a release for future commands and, unless told not to, cache it now."""
     _validate_release(args.name)
     config = _read_config()
     config["release"] = args.name
@@ -458,7 +542,8 @@ def _cmd_release_set(args):
         print(f"Cached {cached} datasets.")
 
 
-def _cmd_release_unset(args):
+def _cmd_release_unset(args: argparse.Namespace) -> None:
+    """Forget the saved release, then report what the fallback now is."""
     config = _read_config()
     config.pop("release", None)
     _write_config(config)
@@ -472,27 +557,32 @@ def _cmd_release_unset(args):
 # --- dataset ---
 
 
-def _cmd_dataset_list(_args):
+def _cmd_dataset_list(_args: argparse.Namespace) -> None:
+    """List the dataset IDs available in the active release."""
     _emit(_metadata.available_datasets())
 
 
-def _cmd_dataset_show(args):
+def _cmd_dataset_show(args: argparse.Namespace) -> None:
+    """Show one dataset's metadata, or a single field of it."""
     if args.full:
         _emit(_metadata.get_all_info(args.key, args.field))
     else:
         _emit(_metadata.get_metadata(args.key, args.field))
 
 
-def _cmd_dataset_urls(args):
+def _cmd_dataset_urls(args: argparse.Namespace) -> None:
+    """Print the file URLs for one dataset."""
     _emit(_metadata.get_urls(args.key, skim=args.skim, protocol=args.protocol, cache=args.cache))
 
 
-def _cmd_dataset_search(args):
+def _cmd_dataset_search(args: argparse.Namespace) -> None:
+    """Find datasets whose metadata field matches a value."""
     value = _coerce_search_value(args.value, args.raw)
     _emit(_metadata.match_metadata(args.field, value, float_tolerance=args.tolerance))
 
 
-def _cmd_dataset_build(args):
+def _cmd_dataset_build(args: argparse.Namespace) -> None:
+    """Turn a JSON definitions file into a sample-name -> URLs mapping."""
     samples_defs = _read_json_file(args.definitions)
     _validate_samples_defs(samples_defs, args.definitions)
     _emit(
@@ -508,28 +598,34 @@ def _cmd_dataset_build(args):
 # --- metadata ---
 
 
-def _cmd_metadata_fields(_args):
+def _cmd_metadata_fields(_args: argparse.Namespace) -> None:
+    """List the metadata fields available in the active release."""
     _emit(_metadata.get_metadata_fields())
 
 
-def _cmd_metadata_keywords(_args):
+def _cmd_metadata_keywords(_args: argparse.Namespace) -> None:
+    """List the keywords used in the active release."""
     _emit(_metadata.available_keywords())
 
 
-def _cmd_metadata_skims(_args):
+def _cmd_metadata_skims(_args: argparse.Namespace) -> None:
+    """List the skims available in the active release."""
     _emit(_metadata.available_skims())
 
 
-def _cmd_metadata_dump(_args):
+def _cmd_metadata_dump(_args: argparse.Namespace) -> None:
+    """Print the whole metadata dictionary for the active release."""
     _emit(_metadata.get_all_metadata())
 
 
-def _cmd_metadata_export(args):
+def _cmd_metadata_export(args: argparse.Namespace) -> None:
+    """Write the active release's metadata to a file."""
     _metadata.save_metadata(args.file)
     _emit({"exported": args.file, "release": _metadata.get_current_release()})
 
 
-def _cmd_metadata_import(args):
+def _cmd_metadata_import(args: argparse.Namespace) -> None:
+    """Load metadata from a file and register it under a release name."""
     _metadata.read_metadata(args.file, release=args.as_release)
     # Persist into the cache so subsequent commands can select this release.
     _save_metadata_cache(_metadata_cache_path(args.as_release))
@@ -539,15 +635,18 @@ def _cmd_metadata_import(args):
 # --- weights ---
 
 
-def _cmd_weights_show(args):
+def _cmd_weights_show(args: argparse.Namespace) -> None:
+    """Show the Monte Carlo weight metadata for one dataset."""
     _emit(_weights.get_weights(args.key, e_tag=args.e_tag))
 
 
-def _cmd_weights_names(args):
+def _cmd_weights_names(args: argparse.Namespace) -> None:
+    """List the weight names for one dataset."""
     _emit(_weights.get_weight_names(args.key, e_tag=args.e_tag))
 
 
-def _cmd_weights_list(_args):
+def _cmd_weights_list(_args: argparse.Namespace) -> None:
+    """List the weight names for every dataset in the active release."""
     # Always the active release: the library only supports the current one, so
     # the global --release (which is validated) is the single way to choose it.
     _emit(_weights.get_all_weights_for_release())
@@ -556,13 +655,14 @@ def _cmd_weights_list(_args):
 # --- cache ---
 
 
-def _cmd_cache_info(args):
+def _cmd_cache_info(args: argparse.Namespace) -> None:
+    """Report which releases are cached on disk, and how old each entry is."""
     entries = []
     for release in sorted(_known_releases()):
         path = _metadata_cache_path(release)
         age = _cache_age(path)
         if age is None:
-            continue
+            continue  # Known release, but nothing cached for it yet.
         entries.append(
             {
                 "release": release,
@@ -585,7 +685,8 @@ def _cmd_cache_info(args):
         print(f"  {entry['release'].ljust(width)}  {state}, {_format_age(entry['age_seconds'])}")
 
 
-def _cmd_cache_clear(args):
+def _cmd_cache_clear(args: argparse.Namespace) -> None:
+    """Delete every cached release, which only ever costs a refetch."""
     removed = []
     # Only ever remove files we know we wrote, never a blind glob of the directory.
     for release in sorted(_known_releases()):
@@ -593,7 +694,7 @@ def _cmd_cache_clear(args):
         try:
             os.remove(path)
         except OSError:
-            continue
+            continue  # Not cached, or already gone: nothing to report.
         removed.append(path)
     if args.json:
         _emit({"removed": removed})
@@ -601,7 +702,12 @@ def _cmd_cache_clear(args):
     print(f"Cleared {len(removed)} cached release{'s' if len(removed) != 1 else ''}.")
 
 
-def _cmd_cache_localize(args):
+def _cmd_cache_localize(args: argparse.Namespace) -> None:
+    """Rewrite cached URLs to point at local files, for the ones that exist.
+
+    Unlike --local-path, which rewrites every URL by basename, this keeps files
+    it can't find on disk as remote URLs, so a partial local copy still works.
+    """
     _metadata.find_all_files(args.path, warnmissing=args.warn_missing)
     release = _metadata.get_current_release()
     _save_metadata_cache(_metadata_cache_path(release))
@@ -614,15 +720,22 @@ def _cmd_cache_localize(args):
 # --- env ---
 
 
-def _cmd_env_install(args):
+def _cmd_env_install(args: argparse.Namespace) -> None:
+    """Install packages at the versions pinned in an environment.yml."""
     _utils.install_from_environment(*args.packages, environment_file=args.environment_file)
     _emit({"installed": list(args.packages) or "all", "environment_file": args.environment_file})
 
 
 # --- Argument parsing ---
+#
+# One builder per command group, each taking the shared subparsers object and
+# attaching its commands to it. Two flags set via set_defaults() control what
+# main() does before dispatching: `loads_metadata` (False for commands that
+# touch only local state) and `needs_full` (True for commands that need the
+# whole release rather than a single dataset lookup).
 
 
-def _add_release_commands(sub):
+def _add_release_commands(sub: _SubParsers) -> None:
     """`release` manages which release other commands act on. Local config only."""
     parser = sub.add_parser("release", help="Inspect or set the release used by default")
     parser.set_defaults(loads_metadata=False)
@@ -653,7 +766,7 @@ def _add_release_commands(sub):
     group.add_parser("unset", help="Forget the saved release").set_defaults(func=_cmd_release_unset)
 
 
-def _add_dataset_commands(sub):
+def _add_dataset_commands(sub: _SubParsers) -> None:
     """`dataset` covers discovery and per-dataset lookups."""
     parser = sub.add_parser("dataset", help="Find datasets and get their metadata or file URLs")
     group = parser.add_subparsers(dest="dataset_command", required=True)
@@ -672,6 +785,8 @@ def _add_dataset_commands(sub):
     p.add_argument("key", help="Dataset number or physics_short name")
     p.add_argument("--skim", default="noskim", help="Skim type (default: noskim)")
     p.add_argument("--protocol", choices=["root", "https", "eos"], default="root")
+    # default=None, not False: the library distinguishes "caller said no cache"
+    # from "caller expressed no preference".
     cache_group = p.add_mutually_exclusive_group()
     cache_group.add_argument("--cache", dest="cache", action="store_true", default=None)
     cache_group.add_argument("--no-cache", dest="cache", action="store_false")
@@ -684,7 +799,7 @@ def _add_dataset_commands(sub):
         help=(
             "Value to match, read as JSON where possible: 20000 matches a number, "
             '\'["top","Alternative"]\' requires both, null finds empty fields, '
-            "anything else is treated as text"
+            "anything else is treated as text. Quote lists so the shell keeps them intact"
         ),
     )
     p.add_argument("--raw", action="store_true", help="Treat the value as plain text, never as JSON")
@@ -695,13 +810,14 @@ def _add_dataset_commands(sub):
     p.add_argument("definitions", help="JSON file mapping sample names to {'dids': [...], 'color': ...}")
     p.add_argument("--skim", default="noskim", help="Skim type (default: noskim)")
     p.add_argument("--protocol", choices=["root", "https", "eos"], default="https")
+    # Here the library's own default is False, so mirror it rather than None.
     cache_group = p.add_mutually_exclusive_group()
     cache_group.add_argument("--cache", dest="cache", action="store_true", default=False)
     cache_group.add_argument("--no-cache", dest="cache", action="store_false")
     p.set_defaults(func=_cmd_dataset_build)
 
 
-def _add_metadata_commands(sub):
+def _add_metadata_commands(sub: _SubParsers) -> None:
     """`metadata` covers release-wide vocabularies and bulk import/export."""
     parser = sub.add_parser("metadata", help="Release-wide metadata vocabularies and bulk transfer")
     group = parser.add_subparsers(dest="metadata_command", required=True)
@@ -723,13 +839,14 @@ def _add_metadata_commands(sub):
     p.add_argument("file", help="Destination file; extension selects the format")
     p.set_defaults(func=_cmd_metadata_export, needs_full=True)
 
+    # Imports read from a file rather than the API, so no release is loaded first.
     p = group.add_parser("import", help="Load metadata from a file into the local cache")
     p.add_argument("file", help="JSON file previously written by `metadata export`")
     p.add_argument("--as-release", dest="as_release", default="custom", help="Name to store it under")
     p.set_defaults(func=_cmd_metadata_import, loads_metadata=False)
 
 
-def _add_weights_commands(sub):
+def _add_weights_commands(sub: _SubParsers) -> None:
     """`weights` covers Monte Carlo weight metadata."""
     parser = sub.add_parser("weights", help="Query Monte Carlo weight metadata")
     group = parser.add_subparsers(dest="weights_command", required=True)
@@ -750,7 +867,7 @@ def _add_weights_commands(sub):
     )
 
 
-def _add_cache_commands(sub):
+def _add_cache_commands(sub: _SubParsers) -> None:
     """`cache` manages the on-disk metadata cache."""
     parser = sub.add_parser("cache", help="Inspect, clear, or localize the metadata cache")
     parser.set_defaults(loads_metadata=False)
@@ -762,11 +879,12 @@ def _add_cache_commands(sub):
     p = group.add_parser("localize", help="Rewrite cached URLs to point at a local copy of the files")
     p.add_argument("path", help="Root directory holding your local copy of the data")
     p.add_argument("--warn-missing", action="store_true", help="Warn about files not found locally")
-    # Needs the release loaded so the rewritten metadata can be saved back.
+    # Overrides the group default: needs the release loaded so the rewritten
+    # metadata can be saved back to the cache.
     p.set_defaults(func=_cmd_cache_localize, loads_metadata=True, needs_full=True)
 
 
-def _add_env_commands(sub):
+def _add_env_commands(sub: _SubParsers) -> None:
     """`env` covers environment setup helpers."""
     parser = sub.add_parser("env", help="Environment setup helpers")
     parser.set_defaults(loads_metadata=False)
@@ -778,7 +896,8 @@ def _add_env_commands(sub):
     p.set_defaults(func=_cmd_env_install)
 
 
-def _build_parser():
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the full parser: global options, then one subparser per command group."""
     parser = argparse.ArgumentParser(
         prog="atlasopenmagic",
         description="Query ATLAS Open Data metadata, file URLs, and MC weights.",
@@ -841,8 +960,15 @@ def _build_parser():
     return parser
 
 
-def main(argv=None) -> int:
-    """Entry point for the `atlasopenmagic` / `atom` console scripts."""
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point for the `atlasopenmagic` / `atom` console scripts.
+
+    Args:
+        argv: Command-line arguments; defaults to sys.argv[1:] when omitted.
+
+    Returns:
+        A process exit code: 0 on success, 1 if the command failed.
+    """
     parser = _build_parser()
     args = parser.parse_args(argv)
 
@@ -853,6 +979,8 @@ def main(argv=None) -> int:
     _metadata.set_verbosity(args.verbosity or "warning")
 
     try:
+        # Commands that only touch local state skip this entirely, so `release
+        # show` and `cache info` stay fast and work offline.
         if args.loads_metadata:
             release, _ = _resolve_release(args.release)
             _apply_release(
@@ -863,6 +991,8 @@ def main(argv=None) -> int:
                 page_size=args.page_size,
             )
         args.func(args)
+    # Errors are reported as a single line rather than a traceback: a stack
+    # trace tells a CLI user nothing they can act on.
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
@@ -874,6 +1004,7 @@ def main(argv=None) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
     finally:
+        # In a finally block so the notice still appears when a command fails.
         _print_update_notice(update_check)
 
     return 0

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -277,16 +277,46 @@ def _read_json_file(path: str):
         return json.load(f)
 
 
+def _format_age(seconds: float) -> str:
+    """Render a cache age the way a person would say it."""
+    for unit, size in (("day", 86400), ("hour", 3600), ("minute", 60)):
+        if seconds >= size:
+            value = int(seconds // size)
+            return f"{value} {unit}{'s' if value != 1 else ''} old"
+    return "just now"
+
+
+def _describe_cache(release: str) -> str:
+    """One-word cache state for `release`, for human-readable output."""
+    age = _cache_age(_metadata_cache_path(release))
+    if age is None:
+        return "not cached"
+    state = "stale" if age >= _METADATA_CACHE_TTL_SECONDS else "fresh"
+    return f"{state}, {_format_age(age)}"
+
+
 # --- release ---
 
 
-def _cmd_release_list(_args):
-    _emit(_metadata.RELEASES_DESC)
+def _cmd_release_list(args):
+    if args.json:
+        _emit(_metadata.RELEASES_DESC)
+        return
+    active, _ = _resolve_release(args.release)
+    width = max(len(name) for name in _metadata.RELEASES_DESC)
+    for name, description in _metadata.RELEASES_DESC.items():
+        marker = "*" if name == active else " "
+        print(f"{marker} {name.ljust(width)}  {description}")
 
 
 def _cmd_release_show(args):
     release, source = _resolve_release(args.release)
-    _emit({"release": release, "source": source})
+    if args.json:
+        _emit({"release": release, "source": source, "cache": _describe_cache(release)})
+        return
+    print(f"Release: {release}")
+    print(f"Source:  {source}")
+    print(f"Cache:   {_describe_cache(release)}")
 
 
 def _cmd_release_set(args):
@@ -294,14 +324,31 @@ def _cmd_release_set(args):
     config = _read_config()
     config["release"] = args.name
     _write_config(config)
-    _emit({"release": args.name, "config_file": _CONFIG_PATH})
+
+    # Warm the cache now, so the cost of fetching a release is paid here where
+    # the user asked for it, rather than ambushing whichever query comes first.
+    cached = None
+    if not args.no_fetch:
+        _apply_release(args.name, refresh=args.refresh, needs_full=True)
+        cached = len(_metadata.available_datasets())
+
+    if args.json:
+        _emit({"release": args.name, "config_file": _CONFIG_PATH, "datasets_cached": cached})
+        return
+    print(f"Release set to {args.name} ({_CONFIG_PATH}).")
+    if cached is not None:
+        print(f"Cached {cached} datasets.")
 
 
-def _cmd_release_unset(_args):
+def _cmd_release_unset(args):
     config = _read_config()
     config.pop("release", None)
     _write_config(config)
-    _emit({"release": None, "config_file": _CONFIG_PATH})
+    if args.json:
+        _emit({"release": None, "config_file": _CONFIG_PATH})
+        return
+    fallback, source = _resolve_release(None)
+    print(f"Saved release cleared. Now using {fallback} (source: {source}).")
 
 
 # --- dataset ---
@@ -389,7 +436,7 @@ def _cmd_weights_list(args):
 # --- cache ---
 
 
-def _cmd_cache_info(_args):
+def _cmd_cache_info(args):
     entries = []
     for release in sorted(_known_releases()):
         path = _metadata_cache_path(release)
@@ -404,10 +451,21 @@ def _cmd_cache_info(_args):
                 "stale": age >= _METADATA_CACHE_TTL_SECONDS,
             }
         )
-    _emit({"cache_dir": _CACHE_DIR, "entries": entries})
+
+    if args.json:
+        _emit({"cache_dir": _CACHE_DIR, "entries": entries})
+        return
+    print(f"Cache directory: {_CACHE_DIR}")
+    if not entries:
+        print("No releases cached.")
+        return
+    width = max(len(e["release"]) for e in entries)
+    for entry in entries:
+        state = "stale" if entry["stale"] else "fresh"
+        print(f"  {entry['release'].ljust(width)}  {state}, {_format_age(entry['age_seconds'])}")
 
 
-def _cmd_cache_clear(_args):
+def _cmd_cache_clear(args):
     removed = []
     # Only ever remove files we know we wrote, never a blind glob of the directory.
     for release in sorted(_known_releases()):
@@ -417,14 +475,20 @@ def _cmd_cache_clear(_args):
         except OSError:
             continue
         removed.append(path)
-    _emit({"removed": removed})
+    if args.json:
+        _emit({"removed": removed})
+        return
+    print(f"Cleared {len(removed)} cached release{'s' if len(removed) != 1 else ''}.")
 
 
 def _cmd_cache_localize(args):
     _metadata.find_all_files(args.path, warnmissing=args.warn_missing)
     release = _metadata.get_current_release()
     _save_metadata_cache(_metadata_cache_path(release))
-    _emit({"localized": args.path, "release": release})
+    if args.json:
+        _emit({"localized": args.path, "release": release})
+        return
+    print(f"Cached metadata for {release} now points at {args.path}.")
 
 
 # --- env ---
@@ -450,6 +514,11 @@ def _add_release_commands(sub):
     )
     p = group.add_parser("set", help="Save a release to use for future commands")
     p.add_argument("name", help="Release name, e.g. 2024r-pp")
+    p.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Save the setting without downloading the release's metadata",
+    )
     p.set_defaults(func=_cmd_release_set)
     group.add_parser("unset", help="Forget the saved release").set_defaults(func=_cmd_release_unset)
 
@@ -595,6 +664,11 @@ def _build_parser():
         "--no-update-check",
         action="store_true",
         help="Skip the PyPI check for a newer atlasopenmagic release",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Force JSON output for commands that otherwise print for humans",
     )
 
     # Most commands only read one dataset; those needing the whole release

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -8,11 +8,10 @@ the update notice) go to stderr.
 
 Unlike a Python session, each CLI invocation is a fresh process, so the
 library's in-memory release selection and metadata cache do not survive
-between commands. Two pieces of on-disk state make up for that:
-
-* a config file holding the release chosen with `atom release set`, and
-* a per-release metadata cache, so repeated commands don't refetch the
-  whole release from the API every time.
+between commands. Two pieces of on-disk state make up for that: a config
+file holding the release chosen with `atom release set`, and a per-release
+metadata cache, so repeated commands don't refetch the whole release from
+the API every time.
 
 Deprecated library functions (`get_urls_data`, `build_mc_dataset`,
 `build_data_dataset`) are deliberately not exposed here; their replacements
@@ -30,9 +29,11 @@ from importlib.metadata import PackageNotFoundError, version
 
 import requests
 
-from . import metadata as _metadata
-from . import utils as _utils
-from . import weights as _weights
+# Absolute imports: lazydocs loads each module without package context, and
+# relative imports break its docs generation (see commit 5c7eb09).
+from atlasopenmagic import metadata as _metadata
+from atlasopenmagic import utils as _utils
+from atlasopenmagic import weights as _weights
 
 _PACKAGE_NAME = "atlasopenmagic"
 _PYPI_URL = f"https://pypi.org/pypi/{_PACKAGE_NAME}/json"

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -1,0 +1,288 @@
+"""Command-line interface for atlasopenmagic.
+
+Installed as both `atlasopenmagic` and `atom`. Wraps the read/query
+functions of the Python API (datasets, metadata, URLs, weights) so they
+can be used from shell scripts and other non-Python tooling. Output is
+JSON on stdout so it composes with tools like `jq`; informational
+messages (including the update notice) go to stderr.
+"""
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from importlib.metadata import PackageNotFoundError, version
+
+import requests
+
+from . import metadata as _metadata
+from . import weights as _weights
+
+_PACKAGE_NAME = "atlasopenmagic"
+_PYPI_URL = f"https://pypi.org/pypi/{_PACKAGE_NAME}/json"
+_CACHE_PATH = os.path.join(
+    os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache")),
+    "atlasopenmagic",
+    "update_check.json",
+)
+_CHECK_INTERVAL_SECONDS = 24 * 3600
+
+
+# --- Update notification (CLI only; never runs on `import atlasopenmagic`) ---
+
+
+def _installed_version():
+    try:
+        return version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return None
+
+
+def _version_tuple(v):
+    """Loose numeric-prefix comparison, good enough for this package's plain X.Y.Z versions."""
+    parts = []
+    for chunk in v.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _read_cache():
+    try:
+        with open(_CACHE_PATH, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_cache(data):
+    try:
+        os.makedirs(os.path.dirname(_CACHE_PATH), exist_ok=True)
+        with open(_CACHE_PATH, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+    except OSError:
+        pass  # Caching is a nice-to-have; never fail the command over it.
+
+
+def _fetch_latest_version():
+    try:
+        resp = requests.get(_PYPI_URL, timeout=2)
+        resp.raise_for_status()
+        return resp.json()["info"]["version"]
+    except (requests.exceptions.RequestException, ValueError, KeyError):
+        return None
+
+
+def _check_for_update(result: dict):
+    """Populate result['notice'] if a newer release is available. Runs in a background thread."""
+    installed = _installed_version()
+    if not installed:
+        return
+
+    cache = _read_cache()
+    now = time.time()
+    if now - cache.get("checked_at", 0) < _CHECK_INTERVAL_SECONDS:
+        latest = cache.get("latest_version")
+    else:
+        latest = _fetch_latest_version()
+        if latest:
+            _write_cache({"checked_at": now, "latest_version": latest})
+
+    if latest and _version_tuple(latest) > _version_tuple(installed):
+        result["notice"] = (
+            f"A new version of atlasopenmagic is available: {installed} -> {latest}\n"
+            "Upgrade with: pip install --upgrade atlasopenmagic"
+        )
+
+
+def _start_update_check(disabled: bool):
+    result = {}
+    if disabled or os.environ.get("ATLASOPENMAGIC_NO_UPDATE_CHECK"):
+        return None
+    thread = threading.Thread(target=_check_for_update, args=(result,), daemon=True)
+    thread.start()
+    return thread, result
+
+
+def _print_update_notice(check):
+    if check is None:
+        return
+    thread, result = check
+    thread.join(timeout=2)
+    if result.get("notice"):
+        print(f"\n{result['notice']}", file=sys.stderr)
+
+
+# --- Output helpers ---
+
+
+def _emit(data):
+    print(json.dumps(data, indent=2, sort_keys=True, default=str))
+
+
+# --- Command implementations ---
+
+
+def _cmd_releases(_args):
+    _emit(_metadata.RELEASES_DESC)
+
+
+def _cmd_current_release(_args):
+    _emit(_metadata.get_current_release())
+
+
+def _cmd_datasets(_args):
+    _emit(_metadata.available_datasets())
+
+
+def _cmd_skims(_args):
+    _emit(_metadata.available_skims())
+
+
+def _cmd_keywords(_args):
+    _emit(_metadata.available_keywords())
+
+
+def _cmd_fields(_args):
+    _emit(_metadata.get_metadata_fields())
+
+
+def _cmd_metadata(args):
+    if args.full:
+        _emit(_metadata.get_all_info(args.key, args.field))
+    else:
+        _emit(_metadata.get_metadata(args.key, args.field))
+
+
+def _cmd_urls(args):
+    _emit(_metadata.get_urls(args.key, skim=args.skim, protocol=args.protocol, cache=args.cache))
+
+
+def _cmd_search(args):
+    _emit(_metadata.match_metadata(args.field, args.value, float_tolerance=args.tolerance))
+
+
+def _cmd_weights(args):
+    _emit(_weights.get_weights(args.key, e_tag=args.e_tag))
+
+
+def _cmd_weight_names(args):
+    _emit(_weights.get_weight_names(args.key, e_tag=args.e_tag))
+
+
+def _cmd_all_weights(args):
+    _emit(_weights.get_all_weights_for_release(release_name=args.for_release))
+
+
+# --- Argument parsing ---
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(
+        prog="atlasopenmagic",
+        description="Query ATLAS Open Data metadata, file URLs, and MC weights.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {_installed_version() or 'unknown'}",
+    )
+    parser.add_argument("--release", help="Data release to use for this command (e.g. 2024r-pp)")
+    parser.add_argument(
+        "--verbosity",
+        choices=["error", "warning", "info", "debug"],
+        help="Log verbosity for the underlying API calls",
+    )
+    parser.add_argument(
+        "--no-update-check",
+        action="store_true",
+        help="Skip the PyPI check for a newer atlasopenmagic release",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("releases", help="List available data releases").set_defaults(func=_cmd_releases)
+    sub.add_parser("current-release", help="Show the active data release").set_defaults(
+        func=_cmd_current_release
+    )
+    sub.add_parser("datasets", help="List dataset IDs for the active release").set_defaults(func=_cmd_datasets)
+    sub.add_parser("skims", help="List available skims for the active release").set_defaults(func=_cmd_skims)
+    sub.add_parser("keywords", help="List available keywords for the active release").set_defaults(
+        func=_cmd_keywords
+    )
+    sub.add_parser("fields", help="List available metadata fields for the active release").set_defaults(
+        func=_cmd_fields
+    )
+
+    p = sub.add_parser("metadata", help="Show metadata for a dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--field", help="Return only this metadata field")
+    p.add_argument("--full", action="store_true", help="Include file_list and skims")
+    p.set_defaults(func=_cmd_metadata)
+
+    p = sub.add_parser("urls", help="Get file URLs for a dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--skim", default="noskim", help="Skim type (default: noskim)")
+    p.add_argument("--protocol", choices=["root", "https", "eos"], default="root")
+    cache_group = p.add_mutually_exclusive_group()
+    cache_group.add_argument("--cache", dest="cache", action="store_true", default=None)
+    cache_group.add_argument("--no-cache", dest="cache", action="store_false")
+    p.set_defaults(func=_cmd_urls)
+
+    p = sub.add_parser("search", help="Find datasets by metadata field/value")
+    p.add_argument("field", help="Metadata field to search, e.g. process")
+    p.add_argument("value", help="Value to match")
+    p.add_argument("--tolerance", type=float, default=0.01, help="Fractional tolerance for float fields")
+    p.set_defaults(func=_cmd_search)
+
+    p = sub.add_parser("weights", help="Get MC weight metadata for a dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--e-tag", dest="e_tag")
+    p.set_defaults(func=_cmd_weights)
+
+    p = sub.add_parser("weight-names", help="List MC weight names for a dataset")
+    p.add_argument("key", help="Dataset number or physics_short name")
+    p.add_argument("--e-tag", dest="e_tag")
+    p.set_defaults(func=_cmd_weight_names)
+
+    p = sub.add_parser("all-weights", help="List weight names for every dataset in a release")
+    p.add_argument("--for-release", dest="for_release", help="Defaults to the active release")
+    p.set_defaults(func=_cmd_all_weights)
+
+    return parser
+
+
+def main(argv=None) -> int:
+    """Entry point for the `atlasopenmagic` / `atom` console scripts."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    update_check = _start_update_check(args.no_update_check)
+
+    if args.verbosity:
+        _metadata.set_verbosity(args.verbosity)
+    if args.release:
+        _metadata.set_release(args.release)
+
+    try:
+        args.func(args)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except requests.exceptions.RequestException as e:
+        print(f"Network error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        _print_update_notice(update_check)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -284,5 +284,5 @@ def main(argv=None) -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())

--- a/src/atlasopenmagic/cli.py
+++ b/src/atlasopenmagic/cli.py
@@ -61,6 +61,12 @@ _METADATA_CACHE_TTL_SECONDS = 7 * 24 * 3600
 # Release names become filenames, so keep them to something obviously safe.
 _SAFE_RELEASE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
+# Sentinel local path meaning "native POSIX EOS access", as set_release() accepts.
+_LOCAL_PATH_EOS = "eos"
+
+# Matches the library's own default for set_release(page_size=...).
+_DEFAULT_PAGE_SIZE = 1000
+
 
 # --- Update notification (CLI only; never runs on `import atlasopenmagic`) ---
 
@@ -241,9 +247,25 @@ def _save_metadata_cache(cache_file: str) -> None:
         pass  # Same as the update cache: never fail a command over a cache write.
 
 
-def _apply_release(release: str, refresh: bool, needs_full: bool) -> None:
-    """Point the library at `release`, loading metadata from cache where possible."""
-    _validate_release(release)
+def _resolve_local_path(release: str, cli_local_path):
+    """Resolve the local data path for `release`: flag first, then saved config."""
+    if cli_local_path is not None:
+        return cli_local_path or None  # An empty --local-path clears it for this run.
+    return _read_config().get("local_paths", {}).get(release)
+
+
+def _apply_local_path(local_path) -> None:
+    """Point the library at a local copy of the data, as set_release(local_path=...) does."""
+    if local_path and local_path != _LOCAL_PATH_EOS and not os.path.isdir(local_path):
+        print(
+            f"Warning: local path '{local_path}' does not exist; URLs will point at it anyway.",
+            file=sys.stderr,
+        )
+    _metadata.current_local_path = local_path
+
+
+def _load_metadata_for(release: str, refresh: bool, needs_full: bool, page_size) -> None:
+    """Populate the library's metadata cache for `release`, from disk where possible."""
     cache_file = _metadata_cache_path(release)
 
     age = None if refresh else _cache_age(cache_file)
@@ -261,8 +283,16 @@ def _apply_release(release: str, refresh: bool, needs_full: bool) -> None:
         _metadata.current_release = release
         return
 
-    _metadata.set_release(release)
+    _metadata.set_release(release, page_size=page_size or _DEFAULT_PAGE_SIZE)
     _save_metadata_cache(cache_file)
+
+
+def _apply_release(release: str, refresh: bool, needs_full: bool, local_path=None, page_size=None) -> None:
+    """Point the library at `release`, loading metadata from cache where possible."""
+    _validate_release(release)
+    _load_metadata_for(release, refresh, needs_full, page_size)
+    # Applied last: set_release() resets current_local_path, so this has to win.
+    _apply_local_path(local_path)
 
 
 # --- Output helpers ---
@@ -275,6 +305,47 @@ def _emit(data):
 def _read_json_file(path: str):
     with open(path, encoding="utf-8") as f:
         return json.load(f)
+
+
+def _coerce_search_value(value: str, raw: bool):
+    """Turn a command-line search value into the type match_metadata expects.
+
+    A shell can only hand over strings, but match_metadata compares some fields
+    by identity: searching an integer field for "20000" silently matches nothing
+    where 20000 matches. Reading the value as JSON recovers ints, floats, lists
+    (which match_metadata treats as AND-matching) and null, while anything that
+    isn't valid JSON stays the plain string it already was.
+    """
+    if raw:
+        return value
+    try:
+        return json.loads(value)
+    except ValueError:
+        return value
+
+
+def _validate_samples_defs(samples_defs, path: str) -> None:
+    """Check a `dataset build` definitions file before handing it to the library.
+
+    build_dataset() iterates `info["dids"]` directly, so a missing key raises a
+    bare KeyError and a string is iterated character by character. Both are easy
+    mistakes to make in a hand-written file, so catch them with a message that
+    names the offending sample.
+    """
+    if not isinstance(samples_defs, dict):
+        raise ValueError(f"{path} must contain a JSON object mapping sample names to definitions.")
+    for name, info in samples_defs.items():
+        if not isinstance(info, dict):
+            raise ValueError(f"{path}: sample '{name}' must be an object with a 'dids' list.")
+        if "dids" not in info:
+            raise ValueError(f"{path}: sample '{name}' is missing 'dids'.")
+        if not isinstance(info["dids"], list):
+            raise ValueError(
+                f"{path}: sample '{name}' has 'dids' as {type(info['dids']).__name__}; "
+                'it must be a list, e.g. "dids": ["301204"].'
+            )
+        if not info["dids"]:
+            raise ValueError(f"{path}: sample '{name}' has an empty 'dids' list.")
 
 
 def _format_age(seconds: float) -> str:
@@ -298,44 +369,91 @@ def _describe_cache(release: str) -> str:
 # --- release ---
 
 
+def _release_catalogue() -> dict[str, str]:
+    """Every selectable release: the published ones, plus anything imported locally."""
+    catalogue = dict(_metadata.RELEASES_DESC)
+    for name in _known_releases():
+        if name not in catalogue:
+            catalogue[name] = "Imported locally with `metadata import`."
+    return catalogue
+
+
 def _cmd_release_list(args):
+    catalogue = _release_catalogue()
     if args.json:
-        _emit(_metadata.RELEASES_DESC)
+        _emit(catalogue)
         return
     active, _ = _resolve_release(args.release)
-    width = max(len(name) for name in _metadata.RELEASES_DESC)
-    for name, description in _metadata.RELEASES_DESC.items():
+    width = max(len(name) for name in catalogue)
+    for name, description in catalogue.items():
         marker = "*" if name == active else " "
         print(f"{marker} {name.ljust(width)}  {description}")
 
 
 def _cmd_release_show(args):
     release, source = _resolve_release(args.release)
+    local_path = _resolve_local_path(release, args.local_path)
     if args.json:
-        _emit({"release": release, "source": source, "cache": _describe_cache(release)})
+        _emit(
+            {
+                "release": release,
+                "source": source,
+                "cache": _describe_cache(release),
+                "local_path": local_path,
+            }
+        )
         return
     print(f"Release: {release}")
     print(f"Source:  {source}")
     print(f"Cache:   {_describe_cache(release)}")
+    print(f"Data:    {local_path or 'remote'}")
 
 
 def _cmd_release_set(args):
     _validate_release(args.name)
     config = _read_config()
     config["release"] = args.name
+
+    # The local path is per-release state, so it is stored per release rather
+    # than as a single global setting. `release set --local-path` wins over a
+    # global --local-path given before the subcommand.
+    chosen_local_path = args.set_local_path if args.set_local_path is not None else args.local_path
+    if chosen_local_path is not None:
+        local_paths = config.setdefault("local_paths", {})
+        if chosen_local_path:
+            local_paths[args.name] = chosen_local_path
+        else:
+            local_paths.pop(args.name, None)
     _write_config(config)
+
+    local_path = _resolve_local_path(args.name, chosen_local_path)
 
     # Warm the cache now, so the cost of fetching a release is paid here where
     # the user asked for it, rather than ambushing whichever query comes first.
     cached = None
     if not args.no_fetch:
-        _apply_release(args.name, refresh=args.refresh, needs_full=True)
+        _apply_release(
+            args.name,
+            refresh=args.refresh,
+            needs_full=True,
+            local_path=local_path,
+            page_size=args.page_size,
+        )
         cached = len(_metadata.available_datasets())
 
     if args.json:
-        _emit({"release": args.name, "config_file": _CONFIG_PATH, "datasets_cached": cached})
+        _emit(
+            {
+                "release": args.name,
+                "config_file": _CONFIG_PATH,
+                "datasets_cached": cached,
+                "local_path": local_path,
+            }
+        )
         return
     print(f"Release set to {args.name} ({_CONFIG_PATH}).")
+    if local_path:
+        print(f"Data path: {local_path}")
     if cached is not None:
         print(f"Cached {cached} datasets.")
 
@@ -370,13 +488,13 @@ def _cmd_dataset_urls(args):
 
 
 def _cmd_dataset_search(args):
-    _emit(_metadata.match_metadata(args.field, args.value, float_tolerance=args.tolerance))
+    value = _coerce_search_value(args.value, args.raw)
+    _emit(_metadata.match_metadata(args.field, value, float_tolerance=args.tolerance))
 
 
 def _cmd_dataset_build(args):
     samples_defs = _read_json_file(args.definitions)
-    if not isinstance(samples_defs, dict):
-        raise ValueError(f"{args.definitions} must contain a JSON object mapping sample names to definitions.")
+    _validate_samples_defs(samples_defs, args.definitions)
     _emit(
         _utils.build_dataset(
             samples_defs,
@@ -429,8 +547,10 @@ def _cmd_weights_names(args):
     _emit(_weights.get_weight_names(args.key, e_tag=args.e_tag))
 
 
-def _cmd_weights_list(args):
-    _emit(_weights.get_all_weights_for_release(release_name=args.for_release))
+def _cmd_weights_list(_args):
+    # Always the active release: the library only supports the current one, so
+    # the global --release (which is validated) is the single way to choose it.
+    _emit(_weights.get_all_weights_for_release())
 
 
 # --- cache ---
@@ -519,6 +639,16 @@ def _add_release_commands(sub):
         action="store_true",
         help="Save the setting without downloading the release's metadata",
     )
+    # A separate dest from the global --local-path: sharing one would let this
+    # subparser's default clobber a value given before the subcommand.
+    p.add_argument(
+        "--local-path",
+        dest="set_local_path",
+        help=(
+            "Remember a local data directory for this release, "
+            f"or '{_LOCAL_PATH_EOS}' for native POSIX EOS paths. Pass '' to forget it."
+        ),
+    )
     p.set_defaults(func=_cmd_release_set)
     group.add_parser("unset", help="Forget the saved release").set_defaults(func=_cmd_release_unset)
 
@@ -549,7 +679,15 @@ def _add_dataset_commands(sub):
 
     p = group.add_parser("search", help="Find datasets whose metadata field matches a value")
     p.add_argument("field", help="Metadata field to search, e.g. process")
-    p.add_argument("value", help="Value to match")
+    p.add_argument(
+        "value",
+        help=(
+            "Value to match, read as JSON where possible: 20000 matches a number, "
+            '\'["top","Alternative"]\' requires both, null finds empty fields, '
+            "anything else is treated as text"
+        ),
+    )
+    p.add_argument("--raw", action="store_true", help="Treat the value as plain text, never as JSON")
     p.add_argument("--tolerance", type=float, default=0.01, help="Fractional tolerance for float fields")
     p.set_defaults(func=_cmd_dataset_search, needs_full=True)
 
@@ -606,9 +744,10 @@ def _add_weights_commands(sub):
     p.add_argument("--e-tag", dest="e_tag")
     p.set_defaults(func=_cmd_weights_names)
 
-    p = group.add_parser("list", help="List weight names for every dataset in a release")
-    p.add_argument("--for-release", dest="for_release", help="Defaults to the active release")
-    p.set_defaults(func=_cmd_weights_list)
+    # Needs the whole release loaded: the library walks available_datasets().
+    group.add_parser("list", help="List weight names for every dataset in the active release").set_defaults(
+        func=_cmd_weights_list, needs_full=True
+    )
 
 
 def _add_cache_commands(sub):
@@ -651,6 +790,14 @@ def _build_parser():
     )
     parser.add_argument("--release", help="Release to use for this command, overriding any saved setting")
     parser.add_argument(
+        "--local-path",
+        dest="local_path",
+        help=(
+            "Read data from this directory instead of streaming it, "
+            f"or '{_LOCAL_PATH_EOS}' for native POSIX EOS paths. Pass '' to ignore a saved path."
+        ),
+    )
+    parser.add_argument(
         "--verbosity",
         choices=["error", "warning", "info", "debug"],
         help="Log verbosity for the underlying API calls",
@@ -661,6 +808,12 @@ def _build_parser():
         help="Ignore cached metadata and refetch from the API",
     )
     parser.add_argument(
+        "--page-size",
+        dest="page_size",
+        type=int,
+        help=f"Datasets to request per API call when fetching a release (default {_DEFAULT_PAGE_SIZE})",
+    )
+    parser.add_argument(
         "--no-update-check",
         action="store_true",
         help="Skip the PyPI check for a newer atlasopenmagic release",
@@ -668,7 +821,7 @@ def _build_parser():
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Force JSON output for commands that otherwise print for humans",
+        help="Print JSON from `release show`, `release list` and `cache info` too (other commands always do)",
     )
 
     # Most commands only read one dataset; those needing the whole release
@@ -702,7 +855,13 @@ def main(argv=None) -> int:
     try:
         if args.loads_metadata:
             release, _ = _resolve_release(args.release)
-            _apply_release(release, args.refresh, args.needs_full)
+            _apply_release(
+                release,
+                args.refresh,
+                args.needs_full,
+                local_path=_resolve_local_path(release, args.local_path),
+                page_size=args.page_size,
+            )
         args.func(args)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -471,6 +471,20 @@ def test_coerce_search_value_raw_keeps_text():
     assert cli._coerce_search_value("20000", raw=True) == "20000"
 
 
+@pytest.mark.parametrize("given", ["[2electron,BSM]", "{a:1}", "  [oops]"])
+def test_coerce_search_value_warns_on_shell_mangled_json(given, capsys):
+    """A value that opens like JSON but doesn't parse is usually unquoted shell input."""
+    assert cli._coerce_search_value(given, raw=False) == given
+    assert "not valid JSON" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("given,raw", [("pp>Zprime>ee", False), ("[2electron,BSM]", True)])
+def test_coerce_search_value_stays_quiet(given, raw, capsys):
+    """No warning for genuine text, nor when --raw says text was intended."""
+    assert cli._coerce_search_value(given, raw=raw) == given
+    assert capsys.readouterr().err == ""
+
+
 def test_search_sends_integers_not_strings(monkeypatch, no_metadata_load):
     captured = {}
     monkeypatch.setattr(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,21 +254,70 @@ def test_apply_release_rejects_unknown_release():
 # --- release group ---
 
 
-def test_release_list_emits_all_releases(capsys):
-    _run("release", "list")
+def test_release_list_json_emits_all_releases(capsys):
+    _run("--json", "release", "list")
     assert json.loads(capsys.readouterr().out) == _metadata_mod.RELEASES_DESC
 
 
-def test_release_show_reports_release_and_source(capsys):
+def test_release_list_marks_the_active_release(capsys):
+    cli._write_config({"release": "2024r-hi"})
+    _run("release", "list")
+    lines = capsys.readouterr().out.splitlines()
+    active = [line for line in lines if line.startswith("*")]
+    assert len(active) == 1
+    assert "2024r-hi" in active[0]
+
+
+def test_release_show_json_reports_release_and_source(capsys):
+    cli._write_config({"release": "2020e-13tev"})
+    _run("--json", "release", "show")
+    out = json.loads(capsys.readouterr().out)
+    assert out["release"] == "2020e-13tev"
+    assert out["source"] == "config"
+    assert out["cache"] == "not cached"
+
+
+def test_release_show_reports_a_warm_cache(capsys, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
+    cli._write_config({"release": "2024r-pp"})
+    _run("release", "show")
+    assert "Cache:   fresh, just now" in capsys.readouterr().out
+
+
+def test_release_show_prints_readable_summary(capsys):
     cli._write_config({"release": "2020e-13tev"})
     _run("release", "show")
-    assert json.loads(capsys.readouterr().out) == {"release": "2020e-13tev", "source": "config"}
+    out = capsys.readouterr().out
+    assert "Release: 2020e-13tev" in out
+    assert "Source:  config" in out
+    assert "Cache:   not cached" in out
 
 
-def test_release_set_persists_choice(capsys):
+def test_release_set_persists_choice_and_warms_cache(capsys, monkeypatch):
+    applied = []
+    monkeypatch.setattr(cli, "_apply_release", lambda release, refresh, needs_full: applied.append(release))
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: ["301204", "410470"])
     assert _run("release", "set", "2024r-hi") == 0
-    assert json.loads(capsys.readouterr().out)["release"] == "2024r-hi"
+    assert applied == ["2024r-hi"]
+    assert "Cached 2 datasets." in capsys.readouterr().out
     assert cli._read_config()["release"] == "2024r-hi"
+
+
+def test_release_set_no_fetch_skips_the_download(capsys, monkeypatch):
+    def fail_if_fetched(*a, **kw):
+        raise AssertionError("--no-fetch must not download metadata")
+
+    monkeypatch.setattr(cli, "_apply_release", fail_if_fetched)
+    assert _run("release", "set", "2024r-hi", "--no-fetch") == 0
+    assert "Cached" not in capsys.readouterr().out
+    assert cli._read_config()["release"] == "2024r-hi"
+
+
+def test_release_set_json_reports_cached_count(capsys, monkeypatch):
+    monkeypatch.setattr(cli, "_apply_release", lambda *a, **kw: None)
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: ["301204"])
+    _run("--json", "release", "set", "2024r-hi")
+    assert json.loads(capsys.readouterr().out)["datasets_cached"] == 1
 
 
 def test_release_set_rejects_unknown_release(capsys):
@@ -280,8 +329,14 @@ def test_release_set_rejects_unknown_release(capsys):
 def test_release_unset_forgets_choice(capsys):
     cli._write_config({"release": "2024r-hi"})
     _run("release", "unset")
-    assert json.loads(capsys.readouterr().out)["release"] is None
+    assert "Saved release cleared" in capsys.readouterr().out
     assert "release" not in cli._read_config()
+
+
+def test_release_unset_json_reports_null(capsys):
+    cli._write_config({"release": "2024r-hi"})
+    _run("--json", "release", "unset")
+    assert json.loads(capsys.readouterr().out)["release"] is None
 
 
 def test_release_set_reports_write_failure(capsys, monkeypatch):
@@ -440,30 +495,72 @@ def test_weights_commands(capsys, monkeypatch, no_metadata_load, argv, func_name
 # --- cache group ---
 
 
-def test_cache_info_lists_cached_releases(capsys, tmp_path):
+def test_cache_info_json_lists_cached_releases(capsys, tmp_path):
     _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
-    _run("cache", "info")
+    _run("--json", "cache", "info")
     out = json.loads(capsys.readouterr().out)
     assert [e["release"] for e in out["entries"]] == ["2024r-pp"]
     assert out["entries"][0]["stale"] is False
 
 
-def test_cache_info_is_empty_when_nothing_cached(capsys):
+def test_cache_info_prints_readable_table(capsys, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
     _run("cache", "info")
+    out = capsys.readouterr().out
+    assert "Cache directory:" in out
+    assert "2024r-pp" in out and "fresh" in out
+
+
+def test_cache_info_json_is_empty_when_nothing_cached(capsys):
+    _run("--json", "cache", "info")
     assert json.loads(capsys.readouterr().out)["entries"] == []
+
+
+def test_cache_info_says_so_when_nothing_cached(capsys):
+    _run("cache", "info")
+    assert "No releases cached." in capsys.readouterr().out
+
+
+def test_cache_info_reports_stale_entries(capsys, tmp_path):
+    cached = tmp_path / "cache" / "metadata-2024r-pp.json"
+    _write_cache_file(cached)
+    stale = time.time() - (cli._METADATA_CACHE_TTL_SECONDS + 86400)
+    os.utime(cached, (stale, stale))
+    _run("cache", "info")
+    assert "stale" in capsys.readouterr().out
 
 
 def test_cache_clear_removes_cached_releases(capsys, tmp_path):
     cached = tmp_path / "cache" / "metadata-2024r-pp.json"
     _write_cache_file(cached)
-    _run("cache", "clear")
+    _run("--json", "cache", "clear")
     assert json.loads(capsys.readouterr().out)["removed"] == [str(cached)]
     assert not cached.exists()
 
 
-def test_cache_clear_is_a_noop_when_nothing_cached(capsys):
+def test_cache_clear_prints_count(capsys, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
     _run("cache", "clear")
+    assert "Cleared 1 cached release." in capsys.readouterr().out
+
+
+def test_cache_clear_is_a_noop_when_nothing_cached(capsys):
+    _run("--json", "cache", "clear")
     assert json.loads(capsys.readouterr().out)["removed"] == []
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0, "just now"),
+        (90, "1 minute old"),
+        (7200, "2 hours old"),
+        (86400, "1 day old"),
+        (259200, "3 days old"),
+    ],
+)
+def test_format_age(seconds, expected):
+    assert cli._format_age(seconds) == expected
 
 
 def test_cache_localize_rewrites_and_persists(capsys, monkeypatch, tmp_path, no_metadata_load):
@@ -475,10 +572,17 @@ def test_cache_localize_rewrites_and_persists(capsys, monkeypatch, tmp_path, no_
 
     monkeypatch.setattr(_metadata_mod, "find_all_files", fake_find_all_files)
     monkeypatch.setattr(_metadata_mod, "get_current_release", lambda: "2024r-pp")
-    assert _run("cache", "localize", "/data", "--warn-missing") == 0
+    assert _run("--json", "cache", "localize", "/data", "--warn-missing") == 0
     assert captured == {"local_path": "/data", "warnmissing": True}
     assert json.loads(capsys.readouterr().out)["localized"] == "/data"
     assert (tmp_path / "cache" / "metadata-2024r-pp.json").exists()
+
+
+def test_cache_localize_prints_confirmation(capsys, monkeypatch, no_metadata_load):
+    monkeypatch.setattr(_metadata_mod, "find_all_files", lambda local_path, warnmissing: None)
+    monkeypatch.setattr(_metadata_mod, "get_current_release", lambda: "2024r-pp")
+    _run("cache", "localize", "/data")
+    assert "now points at /data" in capsys.readouterr().out
 
 
 # --- env group ---

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,60 @@
 """Tests for the atlasopenmagic CLI (the `atlasopenmagic` / `atom` console scripts).
 
-These tests never touch the network: PyPI lookups and the underlying
-metadata/weights functions are mocked throughout.
+These tests never touch the network or the user's real config/cache
+directories: PyPI lookups and the underlying metadata/weights/utils functions
+are mocked, and an autouse fixture redirects all on-disk state into tmp_path.
 """
 
 import json
+import os
 import threading
 import time
 
 import pytest
 
 from atlasopenmagic import cli
+
+# `cli._metadata` is the metadata *module*; `cli._metadata._metadata` is the
+# release cache dict inside it.
+_metadata_mod = cli._metadata
+
+
+@pytest.fixture(autouse=True)
+def isolate_cli_state(tmp_path, monkeypatch):
+    """Keep every test off the real ~/.config and ~/.cache, and off each other's state."""
+    monkeypatch.setattr(cli, "_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(cli, "_CACHE_PATH", str(tmp_path / "cache" / "update_check.json"))
+    monkeypatch.setattr(cli, "_CONFIG_PATH", str(tmp_path / "config" / "config.json"))
+    monkeypatch.delenv("ATLAS_RELEASE", raising=False)
+    monkeypatch.delenv("ATLASOPENMAGIC_NO_UPDATE_CHECK", raising=False)
+
+    # read_metadata()/set_release() mutate module globals directly, so snapshot
+    # and restore them rather than leaking into other test modules.
+    saved_release = _metadata_mod.current_release
+    saved_metadata = dict(_metadata_mod._metadata)
+    saved_fields = list(_metadata_mod.AVAILABLE_FIELDS)
+    yield
+    _metadata_mod.current_release = saved_release
+    _metadata_mod._metadata = saved_metadata
+    _metadata_mod.AVAILABLE_FIELDS = saved_fields
+
+
+@pytest.fixture
+def no_metadata_load(monkeypatch):
+    """Stub out release/metadata loading for tests that only exercise dispatch."""
+    monkeypatch.setattr(cli, "_apply_release", lambda *a, **kw: None)
+
+
+def _write_cache_file(path, payload=None):
+    """Write a minimal but structurally valid metadata cache file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload or {"301204": {"dataset_number": "301204", "e_tag": "e3723"}}))
+
+
+def _run(*argv):
+    """Run the CLI with the update check disabled."""
+    return cli.main(["--no-update-check", *argv])
+
 
 # --- Version comparison ---
 
@@ -40,127 +84,512 @@ def test_installed_version_returns_none_when_package_not_found(monkeypatch):
     assert cli._installed_version() is None
 
 
-# --- Command dispatch ---
+# --- Config file ---
 
 
-def test_metadata_command_emits_json(capsys, monkeypatch):
-    monkeypatch.setattr(cli._metadata, "get_metadata", lambda key, var: {"cross_section_pb": 0.0017})
-    assert cli.main(["--no-update-check", "metadata", "301204"]) == 0
-    out = json.loads(capsys.readouterr().out)
-    assert out == {"cross_section_pb": 0.0017}
+def test_read_config_returns_empty_when_missing():
+    assert cli._read_config() == {}
 
 
-def test_urls_command_passes_options_through(capsys, monkeypatch):
+def test_read_config_ignores_corrupt_file(tmp_path):
+    path = tmp_path / "config" / "config.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json")
+    assert cli._read_config() == {}
+
+
+def test_read_config_ignores_non_dict_json(tmp_path):
+    path = tmp_path / "config" / "config.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(["a", "list"]))
+    assert cli._read_config() == {}
+
+
+def test_write_then_read_config_round_trip():
+    cli._write_config({"release": "2024r-pp"})
+    assert cli._read_config() == {"release": "2024r-pp"}
+
+
+# --- Release selection ---
+
+
+def test_validate_release_accepts_published_release():
+    cli._validate_release("2024r-pp")  # Should not raise.
+
+
+def test_validate_release_rejects_unknown_release():
+    with pytest.raises(ValueError, match="Invalid release"):
+        cli._validate_release("not-a-release")
+
+
+def test_validate_release_accepts_locally_imported_release(tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-custom.json")
+    cli._validate_release("custom")  # Should not raise.
+
+
+def test_metadata_cache_path_rejects_path_traversal():
+    with pytest.raises(ValueError, match="Invalid release name"):
+        cli._metadata_cache_path("../../etc/passwd")
+
+
+def test_known_releases_survives_missing_cache_dir():
+    assert "2024r-pp" in cli._known_releases()
+
+
+def test_resolve_release_prefers_cli_flag(monkeypatch):
+    monkeypatch.setenv("ATLAS_RELEASE", "2024r-hi")
+    cli._write_config({"release": "2020e-13tev"})
+    assert cli._resolve_release("2024r-pp") == ("2024r-pp", "--release")
+
+
+def test_resolve_release_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("ATLAS_RELEASE", "2024r-hi")
+    cli._write_config({"release": "2020e-13tev"})
+    assert cli._resolve_release(None) == ("2024r-hi", "ATLAS_RELEASE")
+
+
+def test_resolve_release_falls_back_to_config():
+    cli._write_config({"release": "2020e-13tev"})
+    assert cli._resolve_release(None) == ("2020e-13tev", "config")
+
+
+def test_resolve_release_falls_back_to_library_default(monkeypatch):
+    monkeypatch.setattr(_metadata_mod, "current_release", "2024r-pp")
+    assert cli._resolve_release(None) == ("2024r-pp", "default")
+
+
+# --- Metadata cache ---
+
+
+def test_cache_age_returns_none_for_missing_file():
+    assert cli._cache_age(cli._metadata_cache_path("2024r-pp")) is None
+
+
+def test_cache_age_returns_seconds_for_existing_file(tmp_path):
+    path = tmp_path / "some-file.json"
+    path.write_text("{}")
+    age = cli._cache_age(str(path))
+    assert age is not None and age < 60
+
+
+def test_save_metadata_cache_ignores_oserror(monkeypatch):
+    def raise_oserror(*a, **kw):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(cli.os, "makedirs", raise_oserror)
+    cli._save_metadata_cache(cli._metadata_cache_path("2024r-pp"))  # Should not raise.
+
+
+def test_apply_release_loads_fresh_cache_without_fetching(monkeypatch, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
+
+    def fail_if_fetched(*a, **kw):
+        raise AssertionError("set_release() should not be called when the cache is fresh")
+
+    monkeypatch.setattr(_metadata_mod, "set_release", fail_if_fetched)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True)
+    assert _metadata_mod.get_current_release() == "2024r-pp"
+    assert "301204" in _metadata_mod._metadata
+
+
+def test_apply_release_refetches_when_cache_is_corrupt(monkeypatch, tmp_path):
+    cache_file = tmp_path / "cache" / "metadata-2024r-pp.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("{ truncated")
+
+    calls = []
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True)
+    assert calls == ["2024r-pp"]
+
+
+def test_apply_release_ignores_stale_cache(monkeypatch, tmp_path):
+    cache_file = tmp_path / "cache" / "metadata-2024r-pp.json"
+    _write_cache_file(cache_file)
+    stale = time.time() - (cli._METADATA_CACHE_TTL_SECONDS + 60)
+    os.utime(cache_file, (stale, stale))
+
+    calls = []
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True)
+    assert calls == ["2024r-pp"]
+
+
+def test_apply_release_refresh_bypasses_fresh_cache(monkeypatch, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
+    calls = []
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
+    cli._apply_release("2024r-pp", refresh=True, needs_full=True)
+    assert calls == ["2024r-pp"]
+
+
+def test_apply_release_is_lazy_when_full_metadata_not_needed(monkeypatch):
+    def fail_if_fetched(*a, **kw):
+        raise AssertionError("single-dataset commands must not trigger a full release fetch")
+
+    monkeypatch.setattr(_metadata_mod, "set_release", fail_if_fetched)
+    cli._apply_release("2024r-hi", refresh=False, needs_full=False)
+    assert _metadata_mod.get_current_release() == "2024r-hi"
+
+
+def test_apply_release_writes_cache_after_fetching(monkeypatch, tmp_path):
+    def fake_set_release(release):
+        _metadata_mod._metadata = {"301204": {"dataset_number": "301204"}}
+
+    monkeypatch.setattr(_metadata_mod, "set_release", fake_set_release)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True)
+    written = tmp_path / "cache" / "metadata-2024r-pp.json"
+    assert written.exists()
+    assert json.loads(written.read_text())["301204"]["dataset_number"] == "301204"
+
+
+def test_apply_release_rejects_unknown_release():
+    with pytest.raises(ValueError, match="Invalid release"):
+        cli._apply_release("bogus", refresh=False, needs_full=False)
+
+
+# --- release group ---
+
+
+def test_release_list_emits_all_releases(capsys):
+    _run("release", "list")
+    assert json.loads(capsys.readouterr().out) == _metadata_mod.RELEASES_DESC
+
+
+def test_release_show_reports_release_and_source(capsys):
+    cli._write_config({"release": "2020e-13tev"})
+    _run("release", "show")
+    assert json.loads(capsys.readouterr().out) == {"release": "2020e-13tev", "source": "config"}
+
+
+def test_release_set_persists_choice(capsys):
+    assert _run("release", "set", "2024r-hi") == 0
+    assert json.loads(capsys.readouterr().out)["release"] == "2024r-hi"
+    assert cli._read_config()["release"] == "2024r-hi"
+
+
+def test_release_set_rejects_unknown_release(capsys):
+    assert _run("release", "set", "not-a-release") == 1
+    assert "Invalid release" in capsys.readouterr().err
+    assert cli._read_config() == {}
+
+
+def test_release_unset_forgets_choice(capsys):
+    cli._write_config({"release": "2024r-hi"})
+    _run("release", "unset")
+    assert json.loads(capsys.readouterr().out)["release"] is None
+    assert "release" not in cli._read_config()
+
+
+def test_release_set_reports_write_failure(capsys, monkeypatch):
+    def raise_oserror(*a, **kw):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(cli.os, "makedirs", raise_oserror)
+    assert _run("release", "set", "2024r-pp") == 1
+    assert "permission denied" in capsys.readouterr().err
+
+
+def test_release_commands_never_load_metadata(monkeypatch, capsys):
+    def fail_if_loaded(*a, **kw):
+        raise AssertionError("release commands must not load metadata")
+
+    monkeypatch.setattr(cli, "_apply_release", fail_if_loaded)
+    assert _run("release", "show") == 0
+    capsys.readouterr()
+
+
+# --- dataset group ---
+
+
+def test_dataset_list_emits_dataset_ids(capsys, monkeypatch, no_metadata_load):
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: ["301204"])
+    _run("dataset", "list")
+    assert json.loads(capsys.readouterr().out) == ["301204"]
+
+
+def test_dataset_show_emits_metadata(capsys, monkeypatch, no_metadata_load):
+    monkeypatch.setattr(_metadata_mod, "get_metadata", lambda key, var: {"cross_section_pb": 0.0017})
+    assert _run("dataset", "show", "301204") == 0
+    assert json.loads(capsys.readouterr().out) == {"cross_section_pb": 0.0017}
+
+
+def test_dataset_show_full_uses_get_all_info(capsys, monkeypatch, no_metadata_load):
+    monkeypatch.setattr(_metadata_mod, "get_all_info", lambda key, var: {"file_list": ["a.root"]})
+    _run("dataset", "show", "301204", "--full")
+    assert json.loads(capsys.readouterr().out) == {"file_list": ["a.root"]}
+
+
+def test_dataset_urls_passes_options_through(capsys, monkeypatch, no_metadata_load):
     captured = {}
 
     def fake_get_urls(key, skim, protocol, cache):
         captured.update(key=key, skim=skim, protocol=protocol, cache=cache)
         return ["root://example/file.root"]
 
-    monkeypatch.setattr(cli._metadata, "get_urls", fake_get_urls)
-    rc = cli.main(["--no-update-check", "urls", "301204", "--skim", "exactly4lep", "--protocol", "https"])
+    monkeypatch.setattr(_metadata_mod, "get_urls", fake_get_urls)
+    rc = _run("dataset", "urls", "301204", "--skim", "exactly4lep", "--protocol", "https")
     assert rc == 0
     assert captured == {"key": "301204", "skim": "exactly4lep", "protocol": "https", "cache": None}
     assert json.loads(capsys.readouterr().out) == ["root://example/file.root"]
 
 
-def test_unknown_dataset_returns_exit_code_1(capsys, monkeypatch):
-    def raise_value_error(key, var):
-        raise ValueError(f"Dataset '{key}' not found")
-
-    monkeypatch.setattr(cli._metadata, "get_metadata", raise_value_error)
-    rc = cli.main(["--no-update-check", "metadata", "does-not-exist"])
-    assert rc == 1
-    assert "not found" in capsys.readouterr().err
-
-
-def test_release_flag_calls_set_release(monkeypatch):
-    calls = []
-    monkeypatch.setattr(cli._metadata, "set_release", lambda release: calls.append(release))
-    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
-    cli.main(["--no-update-check", "--release", "2024r-pp", "datasets"])
-    assert calls == ["2024r-pp"]
-
-
-def test_verbosity_flag_calls_set_verbosity(monkeypatch):
-    calls = []
-    monkeypatch.setattr(cli._metadata, "set_verbosity", lambda level: calls.append(level))
-    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
-    cli.main(["--no-update-check", "--verbosity", "debug", "datasets"])
-    assert calls == ["debug"]
-
-
-def test_releases_command_emits_releases_desc(capsys, monkeypatch):
-    monkeypatch.setattr(cli._metadata, "RELEASES_DESC", {"2024r-pp": "desc"})
-    cli.main(["--no-update-check", "releases"])
-    assert json.loads(capsys.readouterr().out) == {"2024r-pp": "desc"}
-
-
-@pytest.mark.parametrize(
-    "argv,target,func_name,fake_return",
-    [
-        (["current-release"], cli._metadata, "get_current_release", "2024r-pp"),
-        (["skims"], cli._metadata, "available_skims", ["noskim"]),
-        (["keywords"], cli._metadata, "available_keywords", ["top"]),
-        (["fields"], cli._metadata, "get_metadata_fields", ["cross_section_pb"]),
-        (["weights", "301204"], cli._weights, "get_weights", {"weights": []}),
-        (["weight-names", "301204"], cli._weights, "get_weight_names", ["nominal"]),
-        (["all-weights"], cli._weights, "get_all_weights_for_release", {"301204": ["nominal"]}),
-    ],
-)
-def test_simple_commands_emit_underlying_result(capsys, monkeypatch, argv, target, func_name, fake_return):
-    monkeypatch.setattr(target, func_name, lambda *a, **kw: fake_return)
-    rc = cli.main(["--no-update-check", *argv])
-    assert rc == 0
-    assert json.loads(capsys.readouterr().out) == fake_return
-
-
-def test_metadata_command_full_flag_uses_get_all_info(capsys, monkeypatch):
-    monkeypatch.setattr(cli._metadata, "get_all_info", lambda key, var: {"file_list": ["a.root"]})
-    cli.main(["--no-update-check", "metadata", "301204", "--full"])
-    assert json.loads(capsys.readouterr().out) == {"file_list": ["a.root"]}
-
-
-def test_search_command_passes_field_value_tolerance(capsys, monkeypatch):
+def test_dataset_search_passes_field_value_tolerance(capsys, monkeypatch, no_metadata_load):
     captured = {}
 
     def fake_match(field, value, float_tolerance):
         captured.update(field=field, value=value, float_tolerance=float_tolerance)
         return [["301204", "physics_short"]]
 
-    monkeypatch.setattr(cli._metadata, "match_metadata", fake_match)
-    cli.main(["--no-update-check", "search", "process", "pp>Zprime>ee", "--tolerance", "0.1"])
+    monkeypatch.setattr(_metadata_mod, "match_metadata", fake_match)
+    _run("dataset", "search", "process", "pp>Zprime>ee", "--tolerance", "0.1")
     assert captured == {"field": "process", "value": "pp>Zprime>ee", "float_tolerance": 0.1}
     assert json.loads(capsys.readouterr().out) == [["301204", "physics_short"]]
 
 
-def test_network_error_returns_exit_code_1(capsys, monkeypatch):
+def test_dataset_build_reads_definitions_and_emits_mapping(capsys, monkeypatch, tmp_path, no_metadata_load):
+    defs_file = tmp_path / "samples.json"
+    defs_file.write_text(json.dumps({"Signal": {"dids": [301204], "color": "red"}}))
+    captured = {}
+
+    def fake_build(samples_defs, skim, protocol, cache):
+        captured.update(samples_defs=samples_defs, skim=skim, protocol=protocol, cache=cache)
+        return {"Signal": {"list": ["https://example/f.root"], "color": "red"}}
+
+    monkeypatch.setattr(cli._utils, "build_dataset", fake_build)
+    assert _run("dataset", "build", str(defs_file)) == 0
+    assert captured["samples_defs"] == {"Signal": {"dids": [301204], "color": "red"}}
+    assert captured["protocol"] == "https"
+    assert json.loads(capsys.readouterr().out)["Signal"]["color"] == "red"
+
+
+def test_dataset_build_rejects_non_object_definitions(capsys, tmp_path, no_metadata_load):
+    defs_file = tmp_path / "samples.json"
+    defs_file.write_text(json.dumps(["not", "an", "object"]))
+    assert _run("dataset", "build", str(defs_file)) == 1
+    assert "must contain a JSON object" in capsys.readouterr().err
+
+
+def test_dataset_build_reports_missing_file(capsys, tmp_path, no_metadata_load):
+    assert _run("dataset", "build", str(tmp_path / "nope.json")) == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+# --- metadata group ---
+
+
+@pytest.mark.parametrize(
+    "argv,func_name,fake_return",
+    [
+        (["metadata", "fields"], "get_metadata_fields", ["cross_section_pb"]),
+        (["metadata", "keywords"], "available_keywords", ["top"]),
+        (["metadata", "skims"], "available_skims", ["noskim"]),
+        (["metadata", "dump"], "get_all_metadata", {"301204": {}}),
+    ],
+)
+def test_metadata_vocabulary_commands(capsys, monkeypatch, no_metadata_load, argv, func_name, fake_return):
+    monkeypatch.setattr(_metadata_mod, func_name, lambda *a, **kw: fake_return)
+    assert _run(*argv) == 0
+    assert json.loads(capsys.readouterr().out) == fake_return
+
+
+def test_metadata_export_writes_file(capsys, monkeypatch, tmp_path, no_metadata_load):
+    target = tmp_path / "out.json"
+    monkeypatch.setattr(_metadata_mod, "save_metadata", lambda file_name: target.write_text("{}"))
+    monkeypatch.setattr(_metadata_mod, "get_current_release", lambda: "2024r-pp")
+    assert _run("metadata", "export", str(target)) == 0
+    assert json.loads(capsys.readouterr().out)["exported"] == str(target)
+    assert target.exists()
+
+
+def test_metadata_import_loads_file_into_cache(capsys, tmp_path):
+    source = tmp_path / "in.json"
+    source.write_text(json.dumps({"301204": {"dataset_number": "301204"}}))
+    assert _run("metadata", "import", str(source), "--as-release", "mycopy") == 0
+    assert json.loads(capsys.readouterr().out)["release"] == "mycopy"
+    # It must land in the cache so later commands can select it.
+    assert (tmp_path / "cache" / "metadata-mycopy.json").exists()
+    assert _metadata_mod.get_current_release() == "mycopy"
+
+
+def test_metadata_import_reports_missing_file(capsys, tmp_path):
+    assert _run("metadata", "import", str(tmp_path / "nope.json")) == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+# --- weights group ---
+
+
+@pytest.mark.parametrize(
+    "argv,func_name,fake_return",
+    [
+        (["weights", "show", "301204"], "get_weights", {"weights": []}),
+        (["weights", "names", "301204"], "get_weight_names", ["nominal"]),
+        (["weights", "list"], "get_all_weights_for_release", {"301204": ["nominal"]}),
+    ],
+)
+def test_weights_commands(capsys, monkeypatch, no_metadata_load, argv, func_name, fake_return):
+    monkeypatch.setattr(cli._weights, func_name, lambda *a, **kw: fake_return)
+    assert _run(*argv) == 0
+    assert json.loads(capsys.readouterr().out) == fake_return
+
+
+# --- cache group ---
+
+
+def test_cache_info_lists_cached_releases(capsys, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
+    _run("cache", "info")
+    out = json.loads(capsys.readouterr().out)
+    assert [e["release"] for e in out["entries"]] == ["2024r-pp"]
+    assert out["entries"][0]["stale"] is False
+
+
+def test_cache_info_is_empty_when_nothing_cached(capsys):
+    _run("cache", "info")
+    assert json.loads(capsys.readouterr().out)["entries"] == []
+
+
+def test_cache_clear_removes_cached_releases(capsys, tmp_path):
+    cached = tmp_path / "cache" / "metadata-2024r-pp.json"
+    _write_cache_file(cached)
+    _run("cache", "clear")
+    assert json.loads(capsys.readouterr().out)["removed"] == [str(cached)]
+    assert not cached.exists()
+
+
+def test_cache_clear_is_a_noop_when_nothing_cached(capsys):
+    _run("cache", "clear")
+    assert json.loads(capsys.readouterr().out)["removed"] == []
+
+
+def test_cache_localize_rewrites_and_persists(capsys, monkeypatch, tmp_path, no_metadata_load):
+    captured = {}
+
+    def fake_find_all_files(local_path, warnmissing):
+        captured.update(local_path=local_path, warnmissing=warnmissing)
+        _metadata_mod._metadata = {"301204": {"file_list": ["/local/f.root"]}}
+
+    monkeypatch.setattr(_metadata_mod, "find_all_files", fake_find_all_files)
+    monkeypatch.setattr(_metadata_mod, "get_current_release", lambda: "2024r-pp")
+    assert _run("cache", "localize", "/data", "--warn-missing") == 0
+    assert captured == {"local_path": "/data", "warnmissing": True}
+    assert json.loads(capsys.readouterr().out)["localized"] == "/data"
+    assert (tmp_path / "cache" / "metadata-2024r-pp.json").exists()
+
+
+# --- env group ---
+
+
+def test_env_install_passes_packages_through(capsys, monkeypatch):
+    captured = {}
+
+    def fake_install(*packages, environment_file=None):
+        captured.update(packages=packages, environment_file=environment_file)
+
+    monkeypatch.setattr(cli._utils, "install_from_environment", fake_install)
+    assert _run("env", "install", "coffea", "dask", "--environment-file", "env.yml") == 0
+    assert captured == {"packages": ("coffea", "dask"), "environment_file": "env.yml"}
+    assert json.loads(capsys.readouterr().out)["installed"] == ["coffea", "dask"]
+
+
+def test_env_install_with_no_packages_installs_all(capsys, monkeypatch):
+    monkeypatch.setattr(cli._utils, "install_from_environment", lambda *a, **kw: None)
+    _run("env", "install")
+    assert json.loads(capsys.readouterr().out)["installed"] == "all"
+
+
+# --- Global options and error handling ---
+
+
+def test_release_flag_overrides_saved_release(monkeypatch):
+    cli._write_config({"release": "2020e-13tev"})
+    applied = []
+    monkeypatch.setattr(cli, "_apply_release", lambda release, refresh, needs_full: applied.append(release))
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    _run("--release", "2024r-pp", "dataset", "list")
+    assert applied == ["2024r-pp"]
+
+
+def test_refresh_flag_is_passed_to_apply_release(monkeypatch):
+    captured = {}
+
+    def fake_apply(release, refresh, needs_full):
+        captured.update(release=release, refresh=refresh, needs_full=needs_full)
+
+    monkeypatch.setattr(cli, "_apply_release", fake_apply)
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    _run("--refresh", "dataset", "list")
+    assert captured["refresh"] is True
+    assert captured["needs_full"] is True
+
+
+def test_single_dataset_commands_do_not_request_full_metadata(monkeypatch):
+    captured = {}
+
+    def fake_apply(release, refresh, needs_full):
+        captured.update(needs_full=needs_full)
+
+    monkeypatch.setattr(cli, "_apply_release", fake_apply)
+    monkeypatch.setattr(_metadata_mod, "get_metadata", lambda key, var: {})
+    _run("dataset", "show", "301204")
+    assert captured["needs_full"] is False
+
+
+def test_verbosity_flag_calls_set_verbosity(monkeypatch, no_metadata_load):
+    calls = []
+    monkeypatch.setattr(_metadata_mod, "set_verbosity", lambda level: calls.append(level))
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    _run("--verbosity", "debug", "dataset", "list")
+    assert calls == ["debug"]
+
+
+def test_cli_is_quiet_by_default(monkeypatch, no_metadata_load):
+    calls = []
+    monkeypatch.setattr(_metadata_mod, "set_verbosity", lambda level: calls.append(level))
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    _run("dataset", "list")
+    assert calls == ["warning"]
+
+
+def test_unknown_dataset_returns_exit_code_1(capsys, monkeypatch, no_metadata_load):
+    def raise_value_error(key, var):
+        raise ValueError(f"Dataset '{key}' not found")
+
+    monkeypatch.setattr(_metadata_mod, "get_metadata", raise_value_error)
+    assert _run("dataset", "show", "does-not-exist") == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_network_error_returns_exit_code_1(capsys, monkeypatch, no_metadata_load):
     def raise_request_exception(key, var):
         raise cli.requests.exceptions.RequestException("connection failed")
 
-    monkeypatch.setattr(cli._metadata, "get_metadata", raise_request_exception)
-    rc = cli.main(["--no-update-check", "metadata", "301204"])
-    assert rc == 1
+    monkeypatch.setattr(_metadata_mod, "get_metadata", raise_request_exception)
+    assert _run("dataset", "show", "301204") == 1
     assert "Network error" in capsys.readouterr().err
 
 
 # --- Update notification ---
 
 
-def test_no_update_check_flag_skips_pypi_lookup(monkeypatch):
+def test_no_update_check_flag_skips_pypi_lookup(monkeypatch, no_metadata_load):
     called = []
     monkeypatch.setattr(cli, "_fetch_latest_version", lambda: called.append(True))
-    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
-    cli.main(["--no-update-check", "datasets"])
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    _run("dataset", "list")
     assert called == []
 
 
-def test_update_check_env_var_skips_pypi_lookup(monkeypatch):
+def test_update_check_env_var_skips_pypi_lookup(monkeypatch, no_metadata_load):
     called = []
     monkeypatch.setattr(cli, "_fetch_latest_version", lambda: called.append(True))
     monkeypatch.setenv("ATLASOPENMAGIC_NO_UPDATE_CHECK", "1")
-    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
-    cli.main(["datasets"])
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    cli.main(["dataset", "list"])
     assert called == []
 
 
@@ -205,18 +634,16 @@ def test_check_for_update_uses_fresh_cache_without_refetching(monkeypatch):
     assert "1.0.0 -> 2.0.0" in result["notice"]
 
 
-def test_read_write_cache_round_trip(tmp_path, monkeypatch):
-    cache_path = tmp_path / "atlasopenmagic" / "update_check.json"
-    monkeypatch.setattr(cli, "_CACHE_PATH", str(cache_path))
+def test_read_write_cache_round_trip():
     assert cli._read_cache() == {}  # File doesn't exist yet.
     cli._write_cache({"checked_at": 123.0, "latest_version": "1.2.3"})
     assert cli._read_cache() == {"checked_at": 123.0, "latest_version": "1.2.3"}
 
 
-def test_read_cache_ignores_corrupt_file(tmp_path, monkeypatch):
-    cache_path = tmp_path / "update_check.json"
-    cache_path.write_text("not json")
-    monkeypatch.setattr(cli, "_CACHE_PATH", str(cache_path))
+def test_read_cache_ignores_corrupt_file(tmp_path):
+    path = tmp_path / "cache" / "update_check.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json")
     assert cli._read_cache() == {}
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,7 +198,7 @@ def test_apply_release_refetches_when_cache_is_corrupt(monkeypatch, tmp_path):
     cache_file.write_text("{ truncated")
 
     calls = []
-    monkeypatch.setattr(_metadata_mod, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release, **kw: calls.append(release))
     monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
     cli._apply_release("2024r-pp", refresh=False, needs_full=True)
     assert calls == ["2024r-pp"]
@@ -211,7 +211,7 @@ def test_apply_release_ignores_stale_cache(monkeypatch, tmp_path):
     os.utime(cache_file, (stale, stale))
 
     calls = []
-    monkeypatch.setattr(_metadata_mod, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release, **kw: calls.append(release))
     monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
     cli._apply_release("2024r-pp", refresh=False, needs_full=True)
     assert calls == ["2024r-pp"]
@@ -220,7 +220,7 @@ def test_apply_release_ignores_stale_cache(monkeypatch, tmp_path):
 def test_apply_release_refresh_bypasses_fresh_cache(monkeypatch, tmp_path):
     _write_cache_file(tmp_path / "cache" / "metadata-2024r-pp.json")
     calls = []
-    monkeypatch.setattr(_metadata_mod, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release, **kw: calls.append(release))
     monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
     cli._apply_release("2024r-pp", refresh=True, needs_full=True)
     assert calls == ["2024r-pp"]
@@ -236,7 +236,7 @@ def test_apply_release_is_lazy_when_full_metadata_not_needed(monkeypatch):
 
 
 def test_apply_release_writes_cache_after_fetching(monkeypatch, tmp_path):
-    def fake_set_release(release):
+    def fake_set_release(release, **kw):
         _metadata_mod._metadata = {"301204": {"dataset_number": "301204"}}
 
     monkeypatch.setattr(_metadata_mod, "set_release", fake_set_release)
@@ -257,6 +257,22 @@ def test_apply_release_rejects_unknown_release():
 def test_release_list_json_emits_all_releases(capsys):
     _run("--json", "release", "list")
     assert json.loads(capsys.readouterr().out) == _metadata_mod.RELEASES_DESC
+
+
+def test_release_list_includes_locally_imported_releases(capsys, tmp_path):
+    # G9: an imported release is selectable and shows in `cache info`, so it
+    # must not be missing from `release list`.
+    _write_cache_file(tmp_path / "cache" / "metadata-mysnap.json")
+    _run("release", "list")
+    out = capsys.readouterr().out
+    assert "mysnap" in out
+    assert "Imported locally" in out
+
+
+def test_release_list_json_includes_locally_imported_releases(capsys, tmp_path):
+    _write_cache_file(tmp_path / "cache" / "metadata-mysnap.json")
+    _run("--json", "release", "list")
+    assert "mysnap" in json.loads(capsys.readouterr().out)
 
 
 def test_release_list_marks_the_active_release(capsys):
@@ -295,7 +311,7 @@ def test_release_show_prints_readable_summary(capsys):
 
 def test_release_set_persists_choice_and_warms_cache(capsys, monkeypatch):
     applied = []
-    monkeypatch.setattr(cli, "_apply_release", lambda release, refresh, needs_full: applied.append(release))
+    monkeypatch.setattr(cli, "_apply_release", lambda release, *a, **kw: applied.append(release))
     monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: ["301204", "410470"])
     assert _run("release", "set", "2024r-hi") == 0
     assert applied == ["2024r-hi"]
@@ -433,6 +449,77 @@ def test_dataset_build_reports_missing_file(capsys, tmp_path, no_metadata_load):
     assert "Error:" in capsys.readouterr().err
 
 
+# --- dataset search value coercion (G1, G2, G3) ---
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("20000", 20000),  # G1: integer fields compare by identity
+        ("0.001762", 0.001762),
+        ('["top","Alternative"]', ["top", "Alternative"]),  # G2: AND matching
+        ("null", None),  # G3: find empty fields
+        ("pp>Zprime>ee", "pp>Zprime>ee"),  # not JSON -> stays text
+        ("2electron", "2electron"),
+    ],
+)
+def test_coerce_search_value(given, expected):
+    assert cli._coerce_search_value(given, raw=False) == expected
+
+
+def test_coerce_search_value_raw_keeps_text():
+    assert cli._coerce_search_value("20000", raw=True) == "20000"
+
+
+def test_search_sends_integers_not_strings(monkeypatch, no_metadata_load):
+    captured = {}
+    monkeypatch.setattr(
+        _metadata_mod,
+        "match_metadata",
+        lambda field, value, float_tolerance: captured.update(value=value) or [],
+    )
+    _run("dataset", "search", "nEvents", "20000")
+    assert captured["value"] == 20000
+    assert not isinstance(captured["value"], str)
+
+
+def test_search_raw_flag_forces_text(monkeypatch, no_metadata_load):
+    captured = {}
+    monkeypatch.setattr(
+        _metadata_mod,
+        "match_metadata",
+        lambda field, value, float_tolerance: captured.update(value=value) or [],
+    )
+    _run("dataset", "search", "nEvents", "20000", "--raw")
+    assert captured["value"] == "20000"
+
+
+# --- dataset build validation (G6, G7) ---
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        (["not", "an", "object"], "must contain a JSON object"),
+        ({"Signal": "not-an-object"}, "must be an object"),
+        ({"Signal": {"color": "red"}}, "is missing 'dids'"),
+        ({"Signal": {"dids": "301204"}}, "'dids' as str"),
+        ({"Signal": {"dids": []}}, "empty 'dids'"),
+    ],
+)
+def test_dataset_build_rejects_malformed_definitions(capsys, tmp_path, no_metadata_load, payload, expected):
+    defs_file = tmp_path / "samples.json"
+    defs_file.write_text(json.dumps(payload))
+    assert _run("dataset", "build", str(defs_file)) == 1
+    err = capsys.readouterr().err
+    assert expected in err
+    assert "Traceback" not in err
+
+
+def test_validate_samples_defs_accepts_a_good_file():
+    cli._validate_samples_defs({"Signal": {"dids": [301204], "color": "red"}}, "f.json")
+
+
 # --- metadata group ---
 
 
@@ -475,6 +562,114 @@ def test_metadata_import_reports_missing_file(capsys, tmp_path):
     assert "Error:" in capsys.readouterr().err
 
 
+# --- local data path (G4) and page size (G5) ---
+
+
+def test_local_path_flag_beats_saved_config():
+    cli._write_config({"local_paths": {"2024r-pp": "/saved"}})
+    assert cli._resolve_local_path("2024r-pp", "/flag") == "/flag"
+
+
+def test_local_path_falls_back_to_saved_config():
+    cli._write_config({"local_paths": {"2024r-pp": "/saved"}})
+    assert cli._resolve_local_path("2024r-pp", None) == "/saved"
+
+
+def test_local_path_empty_flag_clears_saved_config():
+    cli._write_config({"local_paths": {"2024r-pp": "/saved"}})
+    assert cli._resolve_local_path("2024r-pp", "") is None
+
+
+def test_local_path_is_none_when_never_set():
+    assert cli._resolve_local_path("2024r-pp", None) is None
+
+
+def test_release_set_persists_local_path(capsys, monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_apply_release", lambda *a, **kw: None)
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _run("release", "set", "2024r-pp", "--local-path", str(data_dir))
+    assert cli._read_config()["local_paths"]["2024r-pp"] == str(data_dir)
+    assert f"Data path: {data_dir}" in capsys.readouterr().out
+
+
+def test_release_set_empty_local_path_removes_it(monkeypatch):
+    monkeypatch.setattr(cli, "_apply_release", lambda *a, **kw: None)
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    cli._write_config({"local_paths": {"2024r-pp": "/saved"}})
+    _run("release", "set", "2024r-pp", "--local-path", "")
+    assert "2024r-pp" not in cli._read_config()["local_paths"]
+
+
+def test_apply_local_path_sets_the_library_global(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    cli._apply_local_path(str(data_dir))
+    assert _metadata_mod.current_local_path == str(data_dir)
+    cli._apply_local_path(None)
+    assert _metadata_mod.current_local_path is None
+
+
+def test_apply_local_path_accepts_eos_without_warning(capsys):
+    cli._apply_local_path("eos")
+    assert _metadata_mod.current_local_path == "eos"
+    assert capsys.readouterr().err == ""
+
+
+def test_apply_local_path_warns_for_a_missing_directory(capsys):
+    cli._apply_local_path("/definitely/not/here")
+    assert "does not exist" in capsys.readouterr().err
+    assert _metadata_mod.current_local_path == "/definitely/not/here"
+
+
+def test_apply_release_applies_local_path_after_a_fetch(monkeypatch, tmp_path):
+    # set_release() resets current_local_path, so the ordering matters.
+    def fake_set_release(release, **kw):
+        _metadata_mod.current_local_path = None
+
+    monkeypatch.setattr(_metadata_mod, "set_release", fake_set_release)
+    monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True, local_path="eos")
+    assert _metadata_mod.current_local_path == "eos"
+
+
+def test_release_show_reports_the_local_path(capsys):
+    cli._write_config({"release": "2024r-pp", "local_paths": {"2024r-pp": "eos"}})
+    _run("release", "show")
+    assert "Data:    eos" in capsys.readouterr().out
+
+
+def test_release_show_reports_remote_when_no_local_path(capsys):
+    _run("release", "show")
+    assert "Data:    remote" in capsys.readouterr().out
+
+
+def test_page_size_is_passed_to_set_release(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release, **kw: captured.update(kw))
+    monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True, page_size=250)
+    assert captured["page_size"] == 250
+
+
+def test_page_size_defaults_to_the_library_value(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(_metadata_mod, "set_release", lambda release, **kw: captured.update(kw))
+    monkeypatch.setattr(cli, "_save_metadata_cache", lambda path: None)
+    cli._apply_release("2024r-pp", refresh=False, needs_full=True)
+    assert captured["page_size"] == cli._DEFAULT_PAGE_SIZE
+
+
+def test_global_flags_reach_apply_release(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(cli, "_apply_release", lambda *a, **kw: captured.update(kw))
+    monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
+    _run("--local-path", "eos", "--page-size", "500", "dataset", "list")
+    assert captured["local_path"] == "eos"
+    assert captured["page_size"] == 500
+
+
 # --- weights group ---
 
 
@@ -490,6 +685,35 @@ def test_weights_commands(capsys, monkeypatch, no_metadata_load, argv, func_name
     monkeypatch.setattr(cli._weights, func_name, lambda *a, **kw: fake_return)
     assert _run(*argv) == 0
     assert json.loads(capsys.readouterr().out) == fake_return
+
+
+def test_weights_list_no_longer_accepts_for_release(capsys):
+    # G8: the library only supports the current release, so --release is the
+    # single (validated) way to choose one.
+    with pytest.raises(SystemExit):
+        _run("weights", "list", "--for-release", "2024r-hi")
+    assert "unrecognized arguments" in capsys.readouterr().err
+
+
+def test_weights_list_asks_for_the_active_release_only(monkeypatch, no_metadata_load):
+    captured = {}
+    monkeypatch.setattr(
+        cli._weights,
+        "get_all_weights_for_release",
+        lambda *a, **kw: captured.update(args=a, kwargs=kw) or {},
+    )
+    _run("weights", "list")
+    assert captured == {"args": (), "kwargs": {}}
+
+
+def test_weights_list_loads_full_metadata(monkeypatch):
+    # get_all_weights_for_release() walks available_datasets(), so the whole
+    # release has to be loaded (and therefore cached).
+    captured = {}
+    monkeypatch.setattr(cli, "_apply_release", lambda *a, **kw: captured.update(needs_full=a[2]))
+    monkeypatch.setattr(cli._weights, "get_all_weights_for_release", lambda *a, **kw: {})
+    _run("weights", "list")
+    assert captured["needs_full"] is True
 
 
 # --- cache group ---
@@ -612,7 +836,7 @@ def test_env_install_with_no_packages_installs_all(capsys, monkeypatch):
 def test_release_flag_overrides_saved_release(monkeypatch):
     cli._write_config({"release": "2020e-13tev"})
     applied = []
-    monkeypatch.setattr(cli, "_apply_release", lambda release, refresh, needs_full: applied.append(release))
+    monkeypatch.setattr(cli, "_apply_release", lambda release, *a, **kw: applied.append(release))
     monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
     _run("--release", "2024r-pp", "dataset", "list")
     assert applied == ["2024r-pp"]
@@ -621,8 +845,8 @@ def test_release_flag_overrides_saved_release(monkeypatch):
 def test_refresh_flag_is_passed_to_apply_release(monkeypatch):
     captured = {}
 
-    def fake_apply(release, refresh, needs_full):
-        captured.update(release=release, refresh=refresh, needs_full=needs_full)
+    def fake_apply(release, refresh, needs_full, **kw):
+        captured.update(release=release, refresh=refresh, needs_full=needs_full, **kw)
 
     monkeypatch.setattr(cli, "_apply_release", fake_apply)
     monkeypatch.setattr(_metadata_mod, "available_datasets", lambda: [])
@@ -634,7 +858,7 @@ def test_refresh_flag_is_passed_to_apply_release(monkeypatch):
 def test_single_dataset_commands_do_not_request_full_metadata(monkeypatch):
     captured = {}
 
-    def fake_apply(release, refresh, needs_full):
+    def fake_apply(release, refresh, needs_full, **kw):
         captured.update(needs_full=needs_full)
 
     monkeypatch.setattr(cli, "_apply_release", fake_apply)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,109 @@
+"""Tests for the atlasopenmagic CLI (the `atlasopenmagic` / `atom` console scripts).
+
+These tests never touch the network: PyPI lookups and the underlying
+metadata/weights functions are mocked throughout.
+"""
+
+import json
+
+import pytest
+
+from atlasopenmagic import cli
+
+
+# --- Version comparison ---
+
+
+@pytest.mark.parametrize(
+    "latest,installed,expected",
+    [
+        ("1.10.0", "1.9.1", True),
+        ("1.9.1", "1.9.1", False),
+        ("1.9.0", "1.9.1", False),
+        ("2.0.0", "1.9.1", True),
+    ],
+)
+def test_version_tuple_ordering(latest, installed, expected):
+    assert (cli._version_tuple(latest) > cli._version_tuple(installed)) is expected
+
+
+# --- Command dispatch ---
+
+
+def test_metadata_command_emits_json(capsys, monkeypatch):
+    monkeypatch.setattr(cli._metadata, "get_metadata", lambda key, var: {"cross_section_pb": 0.0017})
+    assert cli.main(["--no-update-check", "metadata", "301204"]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"cross_section_pb": 0.0017}
+
+
+def test_urls_command_passes_options_through(capsys, monkeypatch):
+    captured = {}
+
+    def fake_get_urls(key, skim, protocol, cache):
+        captured.update(key=key, skim=skim, protocol=protocol, cache=cache)
+        return ["root://example/file.root"]
+
+    monkeypatch.setattr(cli._metadata, "get_urls", fake_get_urls)
+    rc = cli.main(["--no-update-check", "urls", "301204", "--skim", "exactly4lep", "--protocol", "https"])
+    assert rc == 0
+    assert captured == {"key": "301204", "skim": "exactly4lep", "protocol": "https", "cache": None}
+    assert json.loads(capsys.readouterr().out) == ["root://example/file.root"]
+
+
+def test_unknown_dataset_returns_exit_code_1(capsys, monkeypatch):
+    def raise_value_error(key, var):
+        raise ValueError(f"Dataset '{key}' not found")
+
+    monkeypatch.setattr(cli._metadata, "get_metadata", raise_value_error)
+    rc = cli.main(["--no-update-check", "metadata", "does-not-exist"])
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_release_flag_calls_set_release(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli._metadata, "set_release", lambda release: calls.append(release))
+    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
+    cli.main(["--no-update-check", "--release", "2024r-pp", "datasets"])
+    assert calls == ["2024r-pp"]
+
+
+# --- Update notification ---
+
+
+def test_no_update_check_flag_skips_pypi_lookup(monkeypatch):
+    called = []
+    monkeypatch.setattr(cli, "_fetch_latest_version", lambda: called.append(True))
+    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
+    cli.main(["--no-update-check", "datasets"])
+    assert called == []
+
+
+def test_update_check_env_var_skips_pypi_lookup(monkeypatch):
+    called = []
+    monkeypatch.setattr(cli, "_fetch_latest_version", lambda: called.append(True))
+    monkeypatch.setenv("ATLASOPENMAGIC_NO_UPDATE_CHECK", "1")
+    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
+    cli.main(["datasets"])
+    assert called == []
+
+
+def test_check_for_update_sets_notice_for_newer_release(monkeypatch):
+    monkeypatch.setattr(cli, "_installed_version", lambda: "1.0.0")
+    monkeypatch.setattr(cli, "_read_cache", dict)
+    monkeypatch.setattr(cli, "_write_cache", lambda data: None)
+    monkeypatch.setattr(cli, "_fetch_latest_version", lambda: "2.0.0")
+    result = {}
+    cli._check_for_update(result)
+    assert "1.0.0 -> 2.0.0" in result["notice"]
+
+
+def test_check_for_update_no_notice_when_up_to_date(monkeypatch):
+    monkeypatch.setattr(cli, "_installed_version", lambda: "1.0.0")
+    monkeypatch.setattr(cli, "_read_cache", dict)
+    monkeypatch.setattr(cli, "_write_cache", lambda data: None)
+    monkeypatch.setattr(cli, "_fetch_latest_version", lambda: "1.0.0")
+    result = {}
+    cli._check_for_update(result)
+    assert "notice" not in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,11 +5,12 @@ metadata/weights functions are mocked throughout.
 """
 
 import json
+import threading
+import time
 
 import pytest
 
 from atlasopenmagic import cli
-
 
 # --- Version comparison ---
 
@@ -25,6 +26,18 @@ from atlasopenmagic import cli
 )
 def test_version_tuple_ordering(latest, installed, expected):
     assert (cli._version_tuple(latest) > cli._version_tuple(installed)) is expected
+
+
+def test_version_tuple_stops_at_non_digit_suffix():
+    assert cli._version_tuple("1.9.1rc2") == (1, 9, 1)
+
+
+def test_installed_version_returns_none_when_package_not_found(monkeypatch):
+    def raise_not_found(_name):
+        raise cli.PackageNotFoundError
+
+    monkeypatch.setattr(cli, "version", raise_not_found)
+    assert cli._installed_version() is None
 
 
 # --- Command dispatch ---
@@ -69,6 +82,68 @@ def test_release_flag_calls_set_release(monkeypatch):
     assert calls == ["2024r-pp"]
 
 
+def test_verbosity_flag_calls_set_verbosity(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cli._metadata, "set_verbosity", lambda level: calls.append(level))
+    monkeypatch.setattr(cli._metadata, "available_datasets", lambda: [])
+    cli.main(["--no-update-check", "--verbosity", "debug", "datasets"])
+    assert calls == ["debug"]
+
+
+def test_releases_command_emits_releases_desc(capsys, monkeypatch):
+    monkeypatch.setattr(cli._metadata, "RELEASES_DESC", {"2024r-pp": "desc"})
+    cli.main(["--no-update-check", "releases"])
+    assert json.loads(capsys.readouterr().out) == {"2024r-pp": "desc"}
+
+
+@pytest.mark.parametrize(
+    "argv,target,func_name,fake_return",
+    [
+        (["current-release"], cli._metadata, "get_current_release", "2024r-pp"),
+        (["skims"], cli._metadata, "available_skims", ["noskim"]),
+        (["keywords"], cli._metadata, "available_keywords", ["top"]),
+        (["fields"], cli._metadata, "get_metadata_fields", ["cross_section_pb"]),
+        (["weights", "301204"], cli._weights, "get_weights", {"weights": []}),
+        (["weight-names", "301204"], cli._weights, "get_weight_names", ["nominal"]),
+        (["all-weights"], cli._weights, "get_all_weights_for_release", {"301204": ["nominal"]}),
+    ],
+)
+def test_simple_commands_emit_underlying_result(capsys, monkeypatch, argv, target, func_name, fake_return):
+    monkeypatch.setattr(target, func_name, lambda *a, **kw: fake_return)
+    rc = cli.main(["--no-update-check", *argv])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == fake_return
+
+
+def test_metadata_command_full_flag_uses_get_all_info(capsys, monkeypatch):
+    monkeypatch.setattr(cli._metadata, "get_all_info", lambda key, var: {"file_list": ["a.root"]})
+    cli.main(["--no-update-check", "metadata", "301204", "--full"])
+    assert json.loads(capsys.readouterr().out) == {"file_list": ["a.root"]}
+
+
+def test_search_command_passes_field_value_tolerance(capsys, monkeypatch):
+    captured = {}
+
+    def fake_match(field, value, float_tolerance):
+        captured.update(field=field, value=value, float_tolerance=float_tolerance)
+        return [["301204", "physics_short"]]
+
+    monkeypatch.setattr(cli._metadata, "match_metadata", fake_match)
+    cli.main(["--no-update-check", "search", "process", "pp>Zprime>ee", "--tolerance", "0.1"])
+    assert captured == {"field": "process", "value": "pp>Zprime>ee", "float_tolerance": 0.1}
+    assert json.loads(capsys.readouterr().out) == [["301204", "physics_short"]]
+
+
+def test_network_error_returns_exit_code_1(capsys, monkeypatch):
+    def raise_request_exception(key, var):
+        raise cli.requests.exceptions.RequestException("connection failed")
+
+    monkeypatch.setattr(cli._metadata, "get_metadata", raise_request_exception)
+    rc = cli.main(["--no-update-check", "metadata", "301204"])
+    assert rc == 1
+    assert "Network error" in capsys.readouterr().err
+
+
 # --- Update notification ---
 
 
@@ -107,3 +182,88 @@ def test_check_for_update_no_notice_when_up_to_date(monkeypatch):
     result = {}
     cli._check_for_update(result)
     assert "notice" not in result
+
+
+def test_check_for_update_skips_when_package_not_installed(monkeypatch):
+    monkeypatch.setattr(cli, "_installed_version", lambda: None)
+    called = []
+    monkeypatch.setattr(cli, "_read_cache", lambda: called.append(True))
+    result = {}
+    cli._check_for_update(result)
+    assert result == {}
+    assert called == []
+
+
+def test_check_for_update_uses_fresh_cache_without_refetching(monkeypatch):
+    monkeypatch.setattr(cli, "_installed_version", lambda: "1.0.0")
+    monkeypatch.setattr(cli, "_read_cache", lambda: {"checked_at": time.time(), "latest_version": "2.0.0"})
+    called = []
+    monkeypatch.setattr(cli, "_fetch_latest_version", lambda: called.append(True))
+    result = {}
+    cli._check_for_update(result)
+    assert called == []
+    assert "1.0.0 -> 2.0.0" in result["notice"]
+
+
+def test_read_write_cache_round_trip(tmp_path, monkeypatch):
+    cache_path = tmp_path / "atlasopenmagic" / "update_check.json"
+    monkeypatch.setattr(cli, "_CACHE_PATH", str(cache_path))
+    assert cli._read_cache() == {}  # File doesn't exist yet.
+    cli._write_cache({"checked_at": 123.0, "latest_version": "1.2.3"})
+    assert cli._read_cache() == {"checked_at": 123.0, "latest_version": "1.2.3"}
+
+
+def test_read_cache_ignores_corrupt_file(tmp_path, monkeypatch):
+    cache_path = tmp_path / "update_check.json"
+    cache_path.write_text("not json")
+    monkeypatch.setattr(cli, "_CACHE_PATH", str(cache_path))
+    assert cli._read_cache() == {}
+
+
+def test_write_cache_ignores_oserror(monkeypatch):
+    def raise_oserror(*a, **kw):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(cli.os, "makedirs", raise_oserror)
+    cli._write_cache({"anything": True})  # Should not raise.
+
+
+def test_fetch_latest_version_success(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"info": {"version": "3.0.0"}}
+
+    monkeypatch.setattr(cli.requests, "get", lambda *a, **kw: FakeResponse())
+    assert cli._fetch_latest_version() == "3.0.0"
+
+
+def test_fetch_latest_version_returns_none_on_request_error(monkeypatch):
+    def raise_connection_error(*a, **kw):
+        raise cli.requests.exceptions.RequestException("no network")
+
+    monkeypatch.setattr(cli.requests, "get", raise_connection_error)
+    assert cli._fetch_latest_version() is None
+
+
+def test_start_update_check_runs_target_in_background_thread(monkeypatch):
+    monkeypatch.setattr(cli, "_check_for_update", lambda result: result.update(notice="new version!"))
+    check = cli._start_update_check(disabled=False)
+    assert check is not None
+    thread, result = check
+    thread.join(timeout=2)
+    assert result == {"notice": "new version!"}
+
+
+def test_print_update_notice_prints_to_stderr(capsys):
+    thread = threading.Thread(target=lambda: None)
+    thread.start()
+    cli._print_update_notice((thread, {"notice": "upgrade me"}))
+    assert "upgrade me" in capsys.readouterr().err
+
+
+def test_print_update_notice_noop_when_check_is_none(capsys):
+    cli._print_update_notice(None)
+    assert capsys.readouterr().err == ""


### PR DESCRIPTION
Wraps the read-only lookup functions (metadata, URLs, weights, search) behind an argparse CLI, installed as both `atlasopenmagic` and `atom`, so the package is usable from shell scripts without Python. 

The CLI also checks PyPI once a day for a newer release and prints a notice to stderr; this never runs on a plain `import atlasopenmagic`.

Also, because why not, supporting py 3.13 and 3.14.